### PR TITLE
LEPL:41 В api-gateway сделать новый ендпоинт (редирект не нужен, завязываем логику внутри сервиса) позволяющий изменить личную информацию

### DIFF
--- a/api-gateway/src/main/java/ru/mentor/controller/UserInfoController.java
+++ b/api-gateway/src/main/java/ru/mentor/controller/UserInfoController.java
@@ -6,8 +6,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import ru.mentor.dto.UserInfoDto;
@@ -66,6 +68,20 @@ public class UserInfoController {
     @PostMapping("/mentor/register")
     public ResponseEntity<?> assignMentorRole() {
         UserInfoDto response = userInfoService.assignMentorRole();
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(
+            summary = "Изменить свою информацию",
+            description = "Позволяет изменить пользовательскую информацию от пользователя",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Пользовательская информация изменена"),
+                    @ApiResponse(responseCode = "404", description = "Пользователь не найден")
+            }
+    )
+    @PutMapping("/me")
+    public ResponseEntity<?> updateMyUserInfo(@RequestBody UserInfoDto updateDto) {
+        UserInfoDto response = userInfoService.updateMyUserInfo(updateDto);
         return ResponseEntity.ok().body(response);
     }
 

--- a/api-gateway/src/main/java/ru/mentor/services/UserInfoService.java
+++ b/api-gateway/src/main/java/ru/mentor/services/UserInfoService.java
@@ -30,4 +30,5 @@ public interface UserInfoService {
      */
     UserInfoDto assignMentorRole();
 
+    UserInfoDto updateMyUserInfo(UserInfoDto updateDto);
 }

--- a/api-gateway/src/main/java/ru/mentor/services/impl/UserInfoServiceImpl.java
+++ b/api-gateway/src/main/java/ru/mentor/services/impl/UserInfoServiceImpl.java
@@ -87,4 +87,27 @@ public class UserInfoServiceImpl implements UserInfoService {
         return baseMapper.mapUserDto(savedUser);
     }
 
+    /**
+     * Изменяет данные текущего (аутентифицированного) пользователя.
+     * Идентификатор пользователя берётся из контекста безопасности.
+     * @param updateDto обновляемые данные текущего пользователя
+     * @return DTO с актуальными данными текущего пользователя
+     */
+    @Override
+    public UserInfoDto updateMyUserInfo(UserInfoDto updateDto) {
+        UserEntity myUser = userService.getCurrentUser();
+
+        String requestId = RqGenerator.generateRqId();
+        log.info(String.format(
+                "[ requestId = %s ] Получен запрос на изменение своей информации юзером [ ID = %d ].",
+                requestId,
+                updateDto.getId()
+        ));
+
+        UserEntity updateMyUser = baseMapper.mapUserEntity(updateDto);
+        updateMyUser.setPassword(myUser.getPassword());
+        UserEntity savedUpdateMyUser = userRepository.save(updateMyUser);
+        return baseMapper.mapUserDto(savedUpdateMyUser);
+    }
+
 }

--- a/api-gateway/src/test/java/ru/mentor/controller/UserInfoControllerTest.java
+++ b/api-gateway/src/test/java/ru/mentor/controller/UserInfoControllerTest.java
@@ -1,0 +1,51 @@
+package ru.mentor.controller;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import ru.mentor.constant.Role;
+import ru.mentor.dto.UserInfoDto;
+import ru.mentor.security.JwtAuthenticationFilter;
+import ru.mentor.services.UserInfoService;
+import ru.mentor.testUtil.TestEntityStubGenerator;
+
+@WebMvcTest(UserInfoController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class UserInfoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserInfoService userInfoService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    void updateMyUserInfo() throws Exception {
+        UserInfoDto updateDto = TestEntityStubGenerator.constructUserInfoDtoWithRole(Role.USER);
+        String jsonResponse = TestEntityStubGenerator.constructUserJsonWithRole(Role.USER);
+
+        Mockito.when(userInfoService.updateMyUserInfo(ArgumentMatchers.any(UserInfoDto.class))).thenReturn(updateDto);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/user/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonResponse))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(updateDto.getId()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.username").value(updateDto.getUsername()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.role").value(updateDto.getRole().name()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.firstName").value(updateDto.getFirstName()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.lastName").value(updateDto.getLastName()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.tgChatId").value(updateDto.getTgChatId()));
+    }
+}

--- a/api-gateway/src/test/java/ru/mentor/services/UserInfoServiceImplTest.java
+++ b/api-gateway/src/test/java/ru/mentor/services/UserInfoServiceImplTest.java
@@ -1,0 +1,61 @@
+package ru.mentor.services;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.mentor.constant.Role;
+import ru.mentor.dto.UserInfoDto;
+import ru.mentor.entity.UserEntity;
+import ru.mentor.mapper.BaseMapper;
+import ru.mentor.repository.UserRepository;
+import ru.mentor.services.impl.UserInfoServiceImpl;
+import ru.mentor.services.impl.UserServiceImpl;
+import ru.mentor.testUtil.TestEntityStubGenerator;
+
+@ExtendWith(MockitoExtension.class)
+public class UserInfoServiceImplTest {
+
+    @Mock
+    private UserServiceImpl userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private BaseMapper baseMapper;
+
+    @InjectMocks
+    private UserInfoServiceImpl userInfoService;
+
+    private final String UPDATED_FIRST_NAME = "updateFirstName";
+
+    @Test
+    public void updateMyUserInfo() {
+        UserInfoDto updateDto = TestEntityStubGenerator.constructUserInfoDtoWithRole(Role.USER);
+        updateDto.setFirstName(UPDATED_FIRST_NAME);
+
+        UserEntity currentUser = TestEntityStubGenerator.constructUserEntityWithRole(Role.USER);
+
+        UserEntity updateEntity = TestEntityStubGenerator.constructUserEntityWithRole(Role.USER);
+        updateEntity.setFirstName(UPDATED_FIRST_NAME);
+
+        Mockito.when(userService.getCurrentUser()).thenReturn(currentUser);
+        Mockito.when(baseMapper.mapUserEntity(updateDto)).thenReturn(updateEntity);
+        Mockito.when(userRepository.save(updateEntity)).thenReturn(updateEntity);
+        Mockito.when(baseMapper.mapUserDto(updateEntity)).thenReturn(updateDto);
+
+        UserInfoDto result = userInfoService.updateMyUserInfo(updateDto);
+
+        Assertions.assertEquals(updateDto, result);
+
+        Mockito.verify(userService).getCurrentUser();
+        Mockito.verify(baseMapper).mapUserEntity(updateDto);
+        Mockito.verify(userRepository).save(updateEntity);
+        Mockito.verify(baseMapper).mapUserDto(updateEntity);
+    }
+}

--- a/common-lib/src/main/java/ru/mentor/testUtil/TestEntityStubGenerator.java
+++ b/common-lib/src/main/java/ru/mentor/testUtil/TestEntityStubGenerator.java
@@ -1,5 +1,7 @@
 package ru.mentor.testUtil;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -61,6 +63,21 @@ public class TestEntityStubGenerator {
                          .tgChatId(TestConstantHolder.tgChatId)
                          .role(role)
                          .build();
+    }
+
+    public static String constructUserJsonWithRole(Role role) throws JsonProcessingException {
+        UserInfoDto dto = UserInfoDto.builder()
+                .id(TestConstantHolder.userId)
+                .username(TestConstantHolder.username)
+                .firstName(TestConstantHolder.firstName)
+                .lastName(TestConstantHolder.lastName)
+                .tgNickname(TestConstantHolder.tgNickname)
+                .tgChatId(TestConstantHolder.tgChatId)
+                .role(role)
+                .build();
+
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(dto);
     }
 
     public static PageImpl<CourseEntity> constructCourseEntityPage(CourseEntity courseEntity) {


### PR DESCRIPTION
В api-gateway чтобы изменить личную информацию (без редиректа) добавил:
1.  в UserInfoController ендпоинт PUT updateMyUserInfo,
2.  в UserInfoService метод updateMyUserInfo,
3.  тесты на метод контроллера и сервиса