### PR TITLE
LEPL-12: unit-тесты (api-gateway, common-lib, reactive-common-lib)

### DIFF
--- a/api-gateway/src/test/java/ru/mentor/controller/AccessControllerTest.java
+++ b/api-gateway/src/test/java/ru/mentor/controller/AccessControllerTest.java
@@ -1,0 +1,106 @@
+package ru.mentor.controller;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import ru.mentor.dto.front.CourseAccessRequest;
+import ru.mentor.dto.front.ModuleAccessRequest;
+import ru.mentor.security.JwtAuthenticationFilter;
+import ru.mentor.services.RedirectAccessService;
+
+@WebMvcTest(AccessController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AccessControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RedirectAccessService redirectAccessService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    void giveCourseAccess_delegatesToRedirectService_returnsOk() throws Exception {
+        Mockito.when(redirectAccessService.giveCourseAccess(ArgumentMatchers.any(CourseAccessRequest.class)))
+                .thenReturn(ResponseEntity.ok().build());
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/access/course/get-access")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": 2,
+                                  "courseId": 10
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+        Mockito.verify(redirectAccessService).giveCourseAccess(ArgumentMatchers.any(CourseAccessRequest.class));
+    }
+
+    @Test
+    void revokeCourseAccess_delegatesToRedirectService_returnsOk() throws Exception {
+        Mockito.when(redirectAccessService.revokeCourseAccess(ArgumentMatchers.any(CourseAccessRequest.class)))
+                .thenReturn(ResponseEntity.ok().build());
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/access/course/delete-access")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": 2,
+                                  "courseId": 10
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+        Mockito.verify(redirectAccessService).revokeCourseAccess(ArgumentMatchers.any(CourseAccessRequest.class));
+    }
+
+    @Test
+    void giveModuleAccess_delegatesToRedirectService_returnsOk() throws Exception {
+        Mockito.when(redirectAccessService.giveModuleAccess(ArgumentMatchers.any(ModuleAccessRequest.class)))
+                .thenReturn(ResponseEntity.ok().build());
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/access/module/get-access")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": 2,
+                                  "courseId": 10,
+                                  "moduleId": 20
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+        Mockito.verify(redirectAccessService).giveModuleAccess(ArgumentMatchers.any(ModuleAccessRequest.class));
+    }
+
+    @Test
+    void revokeModuleAccess_delegatesToRedirectService_returnsOk() throws Exception {
+        Mockito.when(redirectAccessService.revokeModuleAccess(ArgumentMatchers.any(ModuleAccessRequest.class)))
+                .thenReturn(ResponseEntity.ok().build());
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/access/module/delete-access")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": 2,
+                                  "courseId": 10,
+                                  "moduleId": 20
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+        Mockito.verify(redirectAccessService).revokeModuleAccess(ArgumentMatchers.any(ModuleAccessRequest.class));
+    }
+}

--- a/api-gateway/src/test/java/ru/mentor/controller/CourseTagControllerTest.java
+++ b/api-gateway/src/test/java/ru/mentor/controller/CourseTagControllerTest.java
@@ -1,0 +1,112 @@
+package ru.mentor.controller;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import ru.mentor.dto.tag.CourseTagDto;
+import ru.mentor.dto.tag.CreateCourseTagRequest;
+import ru.mentor.security.JwtAuthenticationFilter;
+import ru.mentor.services.RedirectCourseTagService;
+
+@WebMvcTest(CourseTagController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class CourseTagControllerTest {
+
+    private static final Long TAG_ID = 7L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RedirectCourseTagService redirectCourseTagService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    void createTag_delegatesToRedirectService_returnsOkAndBody() throws Exception {
+        CourseTagDto created = CourseTagDto.builder()
+                .id(TAG_ID)
+                .tagName("backend")
+                .createdAt(LocalDateTime.of(2026, 4, 1, 12, 0))
+                .isActive(true)
+                .build();
+
+        Mockito.when(redirectCourseTagService.createCourseTag(ArgumentMatchers.any(CreateCourseTagRequest.class)))
+                .thenReturn(created);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/course-tag/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "tagName": "backend"
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(TAG_ID))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.tagName").value("backend"));
+
+        Mockito.verify(redirectCourseTagService).createCourseTag(ArgumentMatchers.any(CreateCourseTagRequest.class));
+    }
+
+    @Test
+    void deleteTag_delegatesToRedirectService_returnsNoContent() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/course-tag/{tagId}", TAG_ID))
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
+
+        Mockito.verify(redirectCourseTagService).deleteCourseTag(TAG_ID);
+    }
+
+    @Test
+    void getTagById_delegatesToRedirectService_returnsOkAndBody() throws Exception {
+        CourseTagDto dto = CourseTagDto.builder()
+                .id(TAG_ID)
+                .tagName("frontend")
+                .createdAt(LocalDateTime.of(2026, 3, 15, 10, 30))
+                .isActive(true)
+                .build();
+
+        Mockito.when(redirectCourseTagService.getTagById(ArgumentMatchers.eq(TAG_ID)))
+                .thenReturn(dto);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/course-tag/{tagId}", TAG_ID)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(TAG_ID))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.tagName").value("frontend"));
+
+        Mockito.verify(redirectCourseTagService).getTagById(TAG_ID);
+    }
+
+    @Test
+    void getAllTags_delegatesToRedirectService_returnsOkAndList() throws Exception {
+        CourseTagDto first = CourseTagDto.builder()
+                .id(1L)
+                .tagName("java")
+                .createdAt(LocalDateTime.of(2026, 1, 1, 0, 0))
+                .isActive(true)
+                .build();
+
+        Mockito.when(redirectCourseTagService.getAllTags()).thenReturn(List.of(first));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/course-tag/all")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].id").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].tagName").value("java"));
+
+        Mockito.verify(redirectCourseTagService).getAllTags();
+    }
+}

--- a/api-gateway/src/test/java/ru/mentor/controller/ModuleControllerTest.java
+++ b/api-gateway/src/test/java/ru/mentor/controller/ModuleControllerTest.java
@@ -1,0 +1,100 @@
+package ru.mentor.controller;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import ru.mentor.dto.ModuleDto;
+import ru.mentor.dto.front.CreateModuleRequest;
+import ru.mentor.security.JwtAuthenticationFilter;
+import ru.mentor.services.RedirectModuleService;
+
+@WebMvcTest(ModuleController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ModuleControllerTest {
+
+    private static final Long COURSE_ID = 10L;
+    private static final Long MODULE_ID = 1L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RedirectModuleService redirectModuleService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    void createModule_delegatesToRedirectService_returnsOkAndBody() throws Exception {
+        ModuleDto created = ModuleDto.builder()
+                .id(100L)
+                .moduleTitle("Intro")
+                .moduleOrderNumber(1)
+                .moduleContent("# Hello")
+                .isActive(true)
+                .createdAt(LocalDateTime.of(2026, 1, 1, 12, 0))
+                .build();
+
+        Mockito.when(redirectModuleService.createModule(ArgumentMatchers.any(CreateModuleRequest.class)))
+                .thenReturn(created);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/module/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "courseId": 10,
+                                  "moduleTitle": "Intro",
+                                  "moduleOrderNumber": 1,
+                                  "moduleContentDescription": "# Hello"
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(100))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.moduleTitle").value("Intro"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.moduleOrderNumber").value(1));
+
+        Mockito.verify(redirectModuleService).createModule(ArgumentMatchers.any(CreateModuleRequest.class));
+    }
+
+    @Test
+    void deleteModule_delegatesToRedirectService_returnsNoContent() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/module/{courseId}/{moduleId}", COURSE_ID, MODULE_ID))
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
+
+        Mockito.verify(redirectModuleService).deleteModule(COURSE_ID, MODULE_ID);
+    }
+
+    @Test
+    void getModuleById_delegatesToRedirectService_returnsOkAndBody() throws Exception {
+        ModuleDto dto = ModuleDto.builder()
+                .id(50L)
+                .moduleTitle("Basics")
+                .moduleOrderNumber(1)
+                .moduleContent("text")
+                .isActive(true)
+                .createdAt(LocalDateTime.of(2026, 2, 1, 10, 0))
+                .build();
+
+        Mockito.when(redirectModuleService.getModuleById(
+                        ArgumentMatchers.eq(COURSE_ID),
+                        ArgumentMatchers.eq(MODULE_ID)))
+                .thenReturn(dto);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/module/{courseId}/{moduleId}", COURSE_ID, MODULE_ID)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(50))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.moduleTitle").value("Basics"));
+
+        Mockito.verify(redirectModuleService).getModuleById(COURSE_ID, MODULE_ID);
+    }
+}

--- a/api-gateway/src/test/java/ru/mentor/controller/ProgressControllerTest.java
+++ b/api-gateway/src/test/java/ru/mentor/controller/ProgressControllerTest.java
@@ -1,0 +1,79 @@
+package ru.mentor.controller;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import ru.mentor.dto.CourseProgressResponse;
+import ru.mentor.dto.MenteeProgressDto;
+import ru.mentor.security.JwtAuthenticationFilter;
+import ru.mentor.services.RedirectProgressService;
+
+@WebMvcTest(ProgressController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ProgressControllerTest {
+
+    private static final Long COURSE_ID = 10L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RedirectProgressService redirectProgressService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    void getCourseProgressByMentor_delegatesToRedirectService_returnsOkAndBody() throws Exception {
+        CourseProgressResponse body = CourseProgressResponse.builder()
+                .courseId(COURSE_ID)
+                .courseTitle("Test course")
+                .mentee(List.of())
+                .statistic(null)
+                .build();
+
+        Mockito.when(redirectProgressService.getCourseProgressByMentor(ArgumentMatchers.eq(COURSE_ID)))
+                .thenReturn(body);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/progress/course/{courseId}/statistics", COURSE_ID)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.courseId").value(COURSE_ID))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.courseTitle").value("Test course"));
+
+        Mockito.verify(redirectProgressService).getCourseProgressByMentor(COURSE_ID);
+    }
+
+    @Test
+    void getAllUsersAtCourse_delegatesToRedirectService_returnsOkAndList() throws Exception {
+        MenteeProgressDto mentee = MenteeProgressDto.builder()
+                .userId(2L)
+                .firstName("Ivan")
+                .lastName("Ivanov")
+                .currentModuleId(3L)
+                .tgNickname("@ivan")
+                .build();
+
+        Mockito.when(redirectProgressService.getAllUsersAtCourse(ArgumentMatchers.eq(COURSE_ID)))
+                .thenReturn(List.of(mentee));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/progress/course/{courseId}/users", COURSE_ID)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].userId").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].firstName").value("Ivan"));
+
+        Mockito.verify(redirectProgressService).getAllUsersAtCourse(COURSE_ID);
+    }
+}

--- a/api-gateway/src/test/java/ru/mentor/exception/GrpcExceptionMapperTest.java
+++ b/api-gateway/src/test/java/ru/mentor/exception/GrpcExceptionMapperTest.java
@@ -1,0 +1,71 @@
+package ru.mentor.exception;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class GrpcExceptionMapperTest {
+
+    private static final String REQUEST_ID = "rq-123";
+    private final GrpcExceptionMapper grpcExceptionMapper = new GrpcExceptionMapper();
+
+    @Test
+    void mapGrpcExceptionToRuntimeException_notFound_returnsEntityNotFoundException() {
+        String errorMessage = "Сущность не найдена";
+        StatusRuntimeException grpcException =
+                Status.NOT_FOUND.withDescription(errorMessage).asRuntimeException();
+
+        RuntimeException result = grpcExceptionMapper
+                .mapGrpcExceptionToRuntimeException(grpcException, REQUEST_ID);
+
+        EntityNotFoundException exception = assertInstanceOf(EntityNotFoundException.class, result);
+        assertEquals(errorMessage, exception.getMessage());
+        assertEquals(REQUEST_ID, exception.getRequestId());
+    }
+
+    @Test
+    void mapGrpcExceptionToRuntimeException_permissionDenied_returnsCustomAccessDeniedException() {
+        String errorMessage = "Доступ запрещен";
+        StatusRuntimeException grpcException =
+                Status.PERMISSION_DENIED.withDescription(errorMessage).asRuntimeException();
+
+        RuntimeException result = grpcExceptionMapper
+                .mapGrpcExceptionToRuntimeException(grpcException, REQUEST_ID);
+
+        CustomAccessDeniedException exception = assertInstanceOf(CustomAccessDeniedException.class, result);
+        assertEquals(errorMessage, exception.getMessage());
+        assertEquals(REQUEST_ID, exception.getRequestId());
+    }
+
+    @Test
+    void mapGrpcExceptionToRuntimeException_alreadyExists_returnsEntityAlreadyExistsException() {
+        String errorMessage = "Сущность уже существует";
+        StatusRuntimeException grpcException =
+                Status.ALREADY_EXISTS.withDescription(errorMessage).asRuntimeException();
+
+        RuntimeException result = grpcExceptionMapper
+                .mapGrpcExceptionToRuntimeException(grpcException, REQUEST_ID);
+
+        EntityAlreadyExistsException exception = assertInstanceOf(EntityAlreadyExistsException.class, result);
+        assertEquals(errorMessage, exception.getMessage());
+        assertEquals(REQUEST_ID, exception.getRequestId());
+    }
+
+    @Test
+    void mapGrpcExceptionToRuntimeException_otherStatus_returnsGrpcRetryException() {
+        StatusRuntimeException grpcException =
+                Status.INTERNAL.withDescription("Внутренняя ошибка").asRuntimeException();
+
+        RuntimeException result = grpcExceptionMapper
+                .mapGrpcExceptionToRuntimeException(grpcException, REQUEST_ID);
+
+        GrpcRetryException exception = assertInstanceOf(GrpcRetryException.class, result);
+        assertEquals(
+                "Ошибка при вызове внутреннего gRPC-сервиса. grpcStatusCode=INTERNAL, grpcDescription=Внутренняя ошибка",
+                exception.getMessage());
+        assertEquals(REQUEST_ID, exception.getRequestId());
+    }
+}

--- a/api-gateway/src/test/java/ru/mentor/mapper/AccessMapperTest.java
+++ b/api-gateway/src/test/java/ru/mentor/mapper/AccessMapperTest.java
@@ -1,0 +1,60 @@
+package ru.mentor.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.mentor.constant.Role;
+import ru.mentor.dto.GetAccessRequest;
+import ru.mentor.dto.front.CourseAccessRequest;
+import ru.mentor.dto.front.ModuleAccessRequest;
+import ru.mentor.entity.UserEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AccessMapperTest {
+
+    private final AccessMapper accessMapper = new AccessMapper();
+
+    @Test
+    void mapToGetAccessRequest_courseRequest_success() {
+        UserEntity mentor = UserEntity.builder()
+                .id(1L)
+                .username("mentor@test")
+                .role(Role.MENTOR)
+                .build();
+
+        CourseAccessRequest request = new CourseAccessRequest();
+        request.setUserId(2L);
+        request.setCourseId(10L);
+
+        GetAccessRequest result = accessMapper.mapToGetAccessRequest(mentor, request);
+
+        assertNotNull(result);
+        assertEquals(mentor.getId(), result.getMentorId());
+        assertEquals(request.getUserId(), result.getUserId());
+        assertEquals(request.getCourseId(), result.getCourseId());
+        assertNull(result.getModuleId());
+    }
+
+    @Test
+    void mapToGetAccessRequest_moduleRequest_success() {
+        UserEntity mentor = UserEntity.builder()
+                .id(1L)
+                .username("mentor@test")
+                .role(Role.MENTOR)
+                .build();
+
+        ModuleAccessRequest request = new ModuleAccessRequest();
+        request.setUserId(2L);
+        request.setCourseId(10L);
+        request.setModuleId(20L);
+
+        GetAccessRequest result = accessMapper.mapToGetAccessRequest(mentor, request);
+
+        assertNotNull(result);
+        assertEquals(mentor.getId(), result.getMentorId());
+        assertEquals(request.getUserId(), result.getUserId());
+        assertEquals(request.getCourseId(), result.getCourseId());
+        assertEquals(request.getModuleId(), result.getModuleId());
+    }
+}

--- a/api-gateway/src/test/java/ru/mentor/mapper/CourseMapperTest.java
+++ b/api-gateway/src/test/java/ru/mentor/mapper/CourseMapperTest.java
@@ -1,0 +1,221 @@
+package ru.mentor.mapper;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import ru.mentor.common.AllActiveCoursesResponse;
+import ru.mentor.common.AllCoursesResponse;
+import ru.mentor.common.AuthorResponse;
+import ru.mentor.common.CourseResponse;
+import ru.mentor.common.CourseTagResponse;
+import ru.mentor.common.CreateCourseGrpcRequest;
+import ru.mentor.common.DeleteCourseRequest;
+import ru.mentor.common.GetAllActiveCoursesPreviewRequest;
+import ru.mentor.common.GetCourseRequest;
+import ru.mentor.common.GrpcPageRequest;
+import ru.mentor.common.Header;
+import ru.mentor.dto.CourseDto;
+import ru.mentor.dto.UserInfoDto;
+import ru.mentor.dto.tag.CourseTagDto;
+import ru.mentor.dto.front.CreateCourseRequest;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CourseMapperTest {
+
+    @Mock
+    private BaseMapper baseMapper;
+
+    @Mock
+    private AdminCourseMapper adminCourseMapper;
+
+    @Mock
+    private TagGrpcMapper tagGrpcMapper;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @InjectMocks
+    private CourseMapper courseMapper;
+
+    private static final Long USER_ID = 1L;
+    private static final Long COURSE_ID = 10L;
+
+    @Test
+    void constructGrpcCreateRequest_buildsRequestCorrectly() {
+        Header header = Header.newBuilder().setRequestId("rq-1").build();
+
+        CreateCourseRequest request = CreateCourseRequest.builder()
+                .courseName("Course")
+                .courseDescription("Description")
+                .tagIds(List.of(1L, 2L, 3L))
+                .build();
+
+        CreateCourseGrpcRequest result = courseMapper.constructGrpcCreateRequest(header, USER_ID, request);
+
+        assertNotNull(result);
+        assertEquals(header, result.getHeader());
+        assertEquals(USER_ID.longValue(), result.getUserId());
+        assertEquals("Course", result.getCourseName());
+        assertEquals("Description", result.getCourseDescription());
+        assertEquals(List.of(1L, 2L, 3L), result.getTagIdsList());
+    }
+
+    @Test
+    void constructGrpcGetRequest_buildsRequestCorrectly() {
+        Header header = Header.newBuilder().setRequestId("rq-2").build();
+
+        GetCourseRequest result = courseMapper.constructGrpcGetRequest(header, USER_ID, COURSE_ID);
+
+        assertNotNull(result);
+        assertEquals(header, result.getHeader());
+        assertEquals(USER_ID.longValue(), result.getSenderId());
+        assertEquals(COURSE_ID.longValue(), result.getCourseId());
+    }
+
+    @Test
+    void constructGetAllActiveCoursesPreviewRequest_buildsRequestCorrectly() {
+        Header header = Header.newBuilder().setRequestId("rq-3").build();
+
+        GetAllActiveCoursesPreviewRequest result =
+                courseMapper.constructGetAllActiveCoursesPreviewRequest(header, USER_ID);
+
+        assertNotNull(result);
+        assertEquals(header, result.getHeader());
+        assertEquals(USER_ID.longValue(), result.getSenderId());
+    }
+
+    @Test
+    void constructGrpcDeleteRequest_buildsRequestCorrectly() {
+        Header header = Header.newBuilder().setRequestId("rq-4").build();
+
+        DeleteCourseRequest result = courseMapper.constructGrpcDeleteRequest(header, USER_ID, COURSE_ID);
+
+        assertNotNull(result);
+        assertEquals(header, result.getHeader());
+        assertEquals(USER_ID.longValue(), result.getSenderId());
+        assertEquals(COURSE_ID.longValue(), result.getCourseId());
+    }
+
+    @Test
+    void constructGrpcPageRequest_delegatesToBaseMapper() {
+        Header header = Header.newBuilder().setRequestId("rq-5").build();
+        int pageNumber = 1;
+        int pageSize = 20;
+
+        GrpcPageRequest expected = GrpcPageRequest.newBuilder().build();
+        when(baseMapper.constructGrpcPageRequest(header, pageNumber, pageSize, USER_ID))
+                .thenReturn(expected);
+
+        GrpcPageRequest result = courseMapper.constructGrpcPageRequest(header, pageNumber, pageSize, USER_ID);
+
+        assertSame(expected, result);
+        verify(baseMapper).constructGrpcPageRequest(header, pageNumber, pageSize, USER_ID);
+    }
+
+    @Test
+    void mapGrpcCourseResponseToCourseDto_delegatesToAdminCourseMapper() {
+        CourseResponse response = CourseResponse.newBuilder().setCourseId(COURSE_ID).build();
+        CourseDto expected = CourseDto.builder().id(COURSE_ID).build();
+        when(adminCourseMapper.mapGrpcCourseResponseToCourseDto(response)).thenReturn(expected);
+
+        CourseDto result = courseMapper.mapGrpcCourseResponseToCourseDto(response);
+
+        assertSame(expected, result);
+        verify(adminCourseMapper).mapGrpcCourseResponseToCourseDto(response);
+    }
+
+    @Test
+    void mapGrpcCourseResponseToCourseDtoPage_delegatesToAdminCourseMapper() {
+        AllCoursesResponse allCoursesResponse = AllCoursesResponse.newBuilder().build();
+        @SuppressWarnings("unchecked")
+        Page<CourseDto> expectedPage = (Page<CourseDto>) mock(Page.class);
+        when(adminCourseMapper.mapGrpcCourseResponseToCourseDtoPage(allCoursesResponse))
+                .thenReturn(expectedPage);
+
+        Page<CourseDto> result = courseMapper.mapGrpcCourseResponseToCourseDtoPage(allCoursesResponse);
+
+        assertSame(expectedPage, result);
+        verify(adminCourseMapper).mapGrpcCourseResponseToCourseDtoPage(allCoursesResponse);
+    }
+
+    @Test
+    void mapGrpcAllActiveCoursesResponseToCourseDtoList_sortsByTitleAndMapsFields() {
+        Instant now = Instant.now();
+
+        var timestamp = com.google.protobuf.Timestamp.newBuilder()
+                .setSeconds(now.getEpochSecond())
+                .setNanos(now.getNano())
+                .build();
+
+        CourseTagResponse grpcTag = CourseTagResponse.newBuilder()
+                .setId(1L)
+                .setName("tag1")
+                .build();
+
+        AuthorResponse grpcAuthor = AuthorResponse.newBuilder()
+                .setUserId(5L)
+                .setFirstName("John")
+                .setLastName("Doe")
+                .build();
+
+        CourseResponse courseB = CourseResponse.newBuilder()
+                .setCourseId(2L)
+                .setTitle("B course")
+                .setDescription("Desc B")
+                .setCreatedAt(timestamp)
+                .setAuthor(grpcAuthor)
+                .addTags(grpcTag)
+                .build();
+
+        CourseResponse courseA = CourseResponse.newBuilder()
+                .setCourseId(1L)
+                .setTitle("A course")
+                .setDescription("Desc A")
+                .setCreatedAt(timestamp)
+                .setAuthor(grpcAuthor)
+                .addTags(grpcTag)
+                .build();
+
+        AllActiveCoursesResponse response = AllActiveCoursesResponse.newBuilder()
+                .addCourses(courseB)
+                .addCourses(courseA)
+                .build();
+
+        CourseTagDto tagDto = CourseTagDto.builder().id(1L).tagName("tag1").build();
+        when(tagGrpcMapper.fromGrpc(any())).thenReturn(tagDto);
+        when(userMapper.mapGrpcAuthorResponseToUserInfoDto(any()))
+                .thenReturn(UserInfoDto.builder().id(5L).firstName("John").lastName("Doe").build());
+
+        List<CourseDto> result = courseMapper.mapGrpcAllActiveCoursesResponseToCourseDtoList(response);
+
+        assertEquals(2, result.size());
+        assertEquals("A course", result.get(0).getCourseTitle());
+        assertEquals("B course", result.get(1).getCourseTitle());
+
+        LocalDateTime expectedCreatedAt = LocalDateTime.ofEpochSecond(
+                now.getEpochSecond(),
+                now.getNano(),
+                ZoneOffset.UTC
+        );
+
+        assertEquals(expectedCreatedAt, result.get(0).getCreatedAt());
+        assertEquals(expectedCreatedAt, result.get(1).getCreatedAt());
+        assertEquals(List.of(tagDto), result.get(0).getTags());
+        assertEquals(5L, result.get(0).getAuthor().getId());
+    }
+}
+

--- a/api-gateway/src/test/java/ru/mentor/mapper/CourseTagsMapperTest.java
+++ b/api-gateway/src/test/java/ru/mentor/mapper/CourseTagsMapperTest.java
@@ -1,0 +1,75 @@
+package ru.mentor.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.mentor.common.CreateCourseTagGrpcRequest;
+import ru.mentor.common.DeleteCourseTagRequest;
+import ru.mentor.common.GetAllCourseTagsRequest;
+import ru.mentor.common.GetCourseTagRequest;
+import ru.mentor.common.Header;
+import ru.mentor.dto.tag.CreateCourseTagRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class CourseTagsMapperTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long TAG_ID = 10L;
+    private static final String TAG_NAME = "Spring";
+
+    private final CourseTagsMapper courseTagsMapper = new CourseTagsMapper();
+
+    @Test
+    void constructGrpcCreateRequest_buildsRequestCorrectly() {
+        Header header = Header.newBuilder().setRequestId("rq-1").build();
+        CreateCourseTagRequest request = CreateCourseTagRequest.builder()
+                .tagName(TAG_NAME)
+                .build();
+
+        CreateCourseTagGrpcRequest result =
+                courseTagsMapper.constructGrpcCreateRequest(header, USER_ID, request);
+
+        assertNotNull(result);
+        assertEquals(header, result.getHeader());
+        assertEquals(USER_ID.longValue(), result.getSenderId());
+        assertEquals(TAG_NAME, result.getName());
+    }
+
+    @Test
+    void constructGrpcDeleteRequest_buildsRequestCorrectly() {
+        Header header = Header.newBuilder().setRequestId("rq-2").build();
+
+        DeleteCourseTagRequest result =
+                courseTagsMapper.constructGrpcDeleteRequest(header, USER_ID, TAG_ID);
+
+        assertNotNull(result);
+        assertEquals(header, result.getHeader());
+        assertEquals(USER_ID.longValue(), result.getSenderId());
+        assertEquals(TAG_ID.longValue(), result.getTagId());
+    }
+
+    @Test
+    void constructGrpcGetRequest_buildsRequestCorrectly() {
+        Header header = Header.newBuilder().setRequestId("rq-3").build();
+
+        GetCourseTagRequest result =
+                courseTagsMapper.constructGrpcGetRequest(header, USER_ID, TAG_ID);
+
+        assertNotNull(result);
+        assertEquals(header, result.getHeader());
+        assertEquals(USER_ID.longValue(), result.getSenderId());
+        assertEquals(TAG_ID.longValue(), result.getTagId());
+    }
+
+    @Test
+    void constructAllCourseTagsRequest_buildsRequestCorrectly() {
+        Header header = Header.newBuilder().setRequestId("rq-4").build();
+
+        GetAllCourseTagsRequest result =
+                courseTagsMapper.constructAllCourseTagsRequest(header, USER_ID);
+
+        assertNotNull(result);
+        assertEquals(header, result.getHeader());
+        assertEquals(USER_ID.longValue(), result.getSenderId());
+    }
+}

--- a/api-gateway/src/test/java/ru/mentor/mapper/ModuleMapperTest.java
+++ b/api-gateway/src/test/java/ru/mentor/mapper/ModuleMapperTest.java
@@ -1,0 +1,199 @@
+package ru.mentor.mapper;
+
+import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+import ru.mentor.common.CreateModuleGrpcRequest;
+import ru.mentor.common.DeleteModuleRequest;
+import ru.mentor.common.GetModuleRequest;
+import ru.mentor.common.Header;
+import ru.mentor.common.ImportModuleFromFileRequest;
+import ru.mentor.common.ModuleResponse;
+import ru.mentor.dto.ModuleDto;
+import ru.mentor.dto.front.CreateModuleRequest;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ModuleMapperTest {
+
+    @Mock
+    private AdminModuleMapper adminModuleMapper;
+
+    @InjectMocks
+    private ModuleMapper moduleMapper;
+
+    private static final Long SENDER_ID = 1L;
+    private static final Long COURSE_ID = 10L;
+    private static final Long MODULE_ID = 100L;
+    private static final Integer MODULE_ORDER_NUM = 2;
+
+    @Test
+    void constructGrpcGetRequest_withoutModuleId_buildsRequestCorrectly() {
+        Header header = Header.newBuilder().setRequestId("rq-1").build();
+
+        GetModuleRequest result = moduleMapper.constructGrpcGetRequest(
+                header,
+                SENDER_ID,
+                COURSE_ID,
+                MODULE_ORDER_NUM,
+                0L
+        );
+
+        assertNotNull(result);
+        assertEquals(header, result.getHeader());
+        assertEquals(SENDER_ID.longValue(), result.getSenderId());
+        assertEquals(COURSE_ID.longValue(), result.getCourseId());
+        assertEquals(MODULE_ORDER_NUM.intValue(), result.getModuleOrderNumber());
+        assertEquals(0L, result.getModuleId());
+    }
+
+    @Test
+    void constructGrpcGetRequest_withModuleId_buildsRequestCorrectly() {
+        Header header = Header.newBuilder().setRequestId("rq-2").build();
+
+        GetModuleRequest result = moduleMapper.constructGrpcGetRequest(
+                header,
+                SENDER_ID,
+                COURSE_ID,
+                MODULE_ORDER_NUM,
+                MODULE_ID
+        );
+
+        assertNotNull(result);
+        assertEquals(header, result.getHeader());
+        assertEquals(SENDER_ID.longValue(), result.getSenderId());
+        assertEquals(COURSE_ID.longValue(), result.getCourseId());
+        assertEquals(MODULE_ORDER_NUM.intValue(), result.getModuleOrderNumber());
+        assertEquals(MODULE_ID.longValue(), result.getModuleId());
+    }
+
+    @Test
+    void constructGrpcImportFromFileRequest_buildsRequestCorrectly() throws IOException {
+        Header header = Header.newBuilder().setRequestId("rq-3").build();
+
+        CreateModuleRequest createRequest = CreateModuleRequest.builder()
+                .courseId(COURSE_ID)
+                .moduleTitle("Title")
+                .moduleOrderNumber(MODULE_ORDER_NUM)
+                .moduleContentDescription("Content")
+                .build();
+
+        MultipartFile file = mock(MultipartFile.class);
+        byte[] fileBytes = "file-content".getBytes();
+        when(file.getName()).thenReturn("module.md");
+        when(file.getBytes()).thenReturn(fileBytes);
+
+        ImportModuleFromFileRequest result = moduleMapper.constructGrpcImportFromFileRequest(
+                header,
+                SENDER_ID,
+                createRequest,
+                file
+        );
+
+        assertNotNull(result);
+        assertEquals(header, result.getHeader());
+        assertEquals(SENDER_ID.longValue(), result.getSenderId());
+        assertEquals(COURSE_ID.longValue(), result.getCourseId());
+        assertEquals("Title", result.getTitle());
+        assertEquals(MODULE_ORDER_NUM.intValue(), result.getOrderNumber());
+        assertEquals("Content", result.getContent());
+        assertEquals("module.md", result.getFilename());
+        assertEquals(ByteString.copyFrom(fileBytes), result.getFileContent());
+    }
+
+    @Test
+    void constructGrpcCreateRequest_buildsRequestCorrectly() {
+        Header header = Header.newBuilder().setRequestId("rq-4").build();
+
+        CreateModuleRequest createRequest = CreateModuleRequest.builder()
+                .courseId(COURSE_ID)
+                .moduleTitle("Title")
+                .moduleOrderNumber(MODULE_ORDER_NUM)
+                .moduleContentDescription("Content")
+                .build();
+
+        CreateModuleGrpcRequest result = moduleMapper.constructGrpcCreateRequest(
+                header,
+                SENDER_ID,
+                createRequest
+        );
+
+        assertNotNull(result);
+        assertEquals(header, result.getHeader());
+        assertEquals(SENDER_ID.longValue(), result.getSenderId());
+        assertEquals(COURSE_ID.longValue(), result.getCourseId());
+        assertEquals("Title", result.getTitle());
+        assertEquals(MODULE_ORDER_NUM.intValue(), result.getOrderNumber());
+        assertEquals("Content", result.getContent());
+    }
+
+    @Test
+    void constructGrpcDeleteRequest_withoutModuleId_buildsRequestCorrectly() {
+        Header header = Header.newBuilder().setRequestId("rq-5").build();
+
+        DeleteModuleRequest result = moduleMapper.constructGrpcDeleteRequest(
+                header,
+                SENDER_ID,
+                COURSE_ID,
+                MODULE_ORDER_NUM,
+                0L
+        );
+
+        assertNotNull(result);
+        assertEquals(header, result.getHeader());
+        assertEquals(SENDER_ID.longValue(), result.getSenderId());
+        assertEquals(COURSE_ID.longValue(), result.getCourseId());
+        assertEquals(MODULE_ORDER_NUM.intValue(), result.getModuleOrderNumber());
+        assertEquals(0L, result.getModuleId());
+    }
+
+    @Test
+    void constructGrpcDeleteRequest_withModuleId_buildsRequestCorrectly() {
+        Header header = Header.newBuilder().setRequestId("rq-6").build();
+
+        DeleteModuleRequest result = moduleMapper.constructGrpcDeleteRequest(
+                header,
+                SENDER_ID,
+                COURSE_ID,
+                MODULE_ORDER_NUM,
+                MODULE_ID
+        );
+
+        assertNotNull(result);
+        assertEquals(header, result.getHeader());
+        assertEquals(SENDER_ID.longValue(), result.getSenderId());
+        assertEquals(COURSE_ID.longValue(), result.getCourseId());
+        assertEquals(MODULE_ORDER_NUM.intValue(), result.getModuleOrderNumber());
+        assertEquals(MODULE_ID.longValue(), result.getModuleId());
+    }
+
+    @Test
+    void mapGrpcModuleResponseToModuleDto_delegatesToAdminModuleMapper() {
+        ModuleResponse moduleResponse = ModuleResponse.newBuilder()
+                .setModuleId(MODULE_ID)
+                .setTitle("Title")
+                .build();
+
+        ModuleDto expectedDto = ModuleDto.builder().build();
+        when(adminModuleMapper.mapGrpcModuleResponseToModuleDto(moduleResponse)).thenReturn(expectedDto);
+
+        ModuleDto result = moduleMapper.mapGrpcModuleResponseToModuleDto(moduleResponse);
+
+        assertNotNull(result);
+        assertSame(expectedDto, result);
+        verify(adminModuleMapper).mapGrpcModuleResponseToModuleDto(moduleResponse);
+    }
+}
+

--- a/api-gateway/src/test/java/ru/mentor/services/impl/AuthenticationServiceImplTest.java
+++ b/api-gateway/src/test/java/ru/mentor/services/impl/AuthenticationServiceImplTest.java
@@ -1,0 +1,174 @@
+package ru.mentor.services.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import ru.mentor.constant.Role;
+import ru.mentor.dto.auth.AuthRequest;
+import ru.mentor.dto.auth.JwtAuthResponse;
+import org.springframework.web.multipart.MultipartFile;
+import ru.mentor.dto.auth.RegRequest;
+import ru.mentor.entity.UserEntity;
+import ru.mentor.kafka.KafkaFacade;
+import ru.mentor.services.JwtService;
+import ru.mentor.services.UserAvatarService;
+import ru.mentor.services.UserService;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticationServiceImplTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private KafkaFacade kafkaFacade;
+
+    @Mock
+    private UserAvatarService userAvatarService;
+
+    @Mock
+    private UserDetailsService userDetailsService;
+
+    @InjectMocks
+    private AuthenticationServiceImpl authenticationService;
+
+    private static final String TG_NICKNAME = "@user_test";
+    private static final String FIRST_NAME = "Влад";
+    private static final String LAST_NAME = "Юрин";
+    private static final String USERNAME = "user@test";
+    private static final String PASSWORD = "password123";
+    private static final String ACCESS_TOKEN = "access-token";
+    private static final String REFRESH_TOKEN = "refresh-token";
+
+    private UserEntity testUser;
+    private AuthRequest authRequest;
+
+    @BeforeEach
+    void setUp() {
+        testUser = UserEntity.builder()
+                .id(1L)
+                .username(USERNAME)
+                .password("encoded")
+                .role(Role.USER)
+                .build();
+
+        authRequest = new AuthRequest(USERNAME, PASSWORD);
+    }
+
+    @Test
+    void registration_withoutAvatar_createsUserAndReturnsTokens() {
+        RegRequest request = new RegRequest(USERNAME, PASSWORD);
+        request.setTgNickname(TG_NICKNAME);
+        request.setFirstName(FIRST_NAME);
+        request.setLastName(LAST_NAME);
+
+        when(passwordEncoder.encode(PASSWORD)).thenReturn("encoded");
+        when(userService.create(any(UserEntity.class))).thenReturn(testUser);
+        when(jwtService.generateToken(testUser)).thenReturn(ACCESS_TOKEN);
+        when(jwtService.generateRefreshToken(testUser)).thenReturn(REFRESH_TOKEN);
+
+        JwtAuthResponse result = authenticationService.registration(request, null);
+
+        assertNotNull(result);
+        assertEquals(ACCESS_TOKEN, result.getAccessToken());
+        assertEquals(REFRESH_TOKEN, result.getRefreshToken());
+        assertEquals(Role.USER, result.getRole());
+    }
+
+    @Test
+    void registration_withAvatar_uploadsAvatarAndReturnsTokens() {
+        RegRequest request = new RegRequest(USERNAME, PASSWORD);
+        request.setTgNickname(TG_NICKNAME);
+        request.setFirstName(FIRST_NAME);
+        request.setLastName(LAST_NAME);
+
+        MultipartFile mockAvatar = mock(MultipartFile.class);
+        String avatarKey = "avatars/user-123.jpg";
+
+        when(userAvatarService.uploadUserAvatar(mockAvatar)).thenReturn(avatarKey);
+        when(passwordEncoder.encode(PASSWORD)).thenReturn("encoded");
+        when(userService.create(any(UserEntity.class))).thenReturn(testUser);
+        when(jwtService.generateToken(testUser)).thenReturn(ACCESS_TOKEN);
+        when(jwtService.generateRefreshToken(testUser)).thenReturn(REFRESH_TOKEN);
+
+        JwtAuthResponse result = authenticationService.registration(request, mockAvatar);
+
+        verify(userAvatarService).uploadUserAvatar(eq(mockAvatar));
+        assertNotNull(result);
+        assertEquals(ACCESS_TOKEN, result.getAccessToken());
+        assertEquals(REFRESH_TOKEN, result.getRefreshToken());
+        assertEquals(Role.USER, result.getRole());
+    }
+
+    @Test
+    void authentication_validCredentials_returnsTokens() {
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(new UsernamePasswordAuthenticationToken(USERNAME, PASSWORD, List.of()));
+        when(userService.getByUsername(USERNAME)).thenReturn(testUser);
+        when(jwtService.generateToken(testUser)).thenReturn(ACCESS_TOKEN);
+        when(jwtService.generateRefreshToken(testUser)).thenReturn(REFRESH_TOKEN);
+
+        JwtAuthResponse result = authenticationService.authentication(authRequest);
+
+        assertNotNull(result);
+        assertEquals(ACCESS_TOKEN, result.getAccessToken());
+        assertEquals(REFRESH_TOKEN, result.getRefreshToken());
+        assertEquals(Role.USER, result.getRole());
+    }
+
+    @Test
+    void refreshToken_validToken_returnsNewTokens() {
+        when(jwtService.extractUserName(REFRESH_TOKEN)).thenReturn(USERNAME);
+        when(userService.userDetailsService()).thenReturn(userDetailsService);
+        when(userDetailsService.loadUserByUsername(USERNAME)).thenReturn(testUser);
+        when(jwtService.isTokenValid(REFRESH_TOKEN, testUser)).thenReturn(true);
+        when(jwtService.generateToken(testUser)).thenReturn(ACCESS_TOKEN);
+        when(jwtService.generateRefreshToken(testUser)).thenReturn(REFRESH_TOKEN);
+
+        JwtAuthResponse result = authenticationService.refreshToken(REFRESH_TOKEN);
+
+        assertNotNull(result);
+        assertEquals(ACCESS_TOKEN, result.getAccessToken());
+        assertEquals(REFRESH_TOKEN, result.getRefreshToken());
+    }
+
+    @Test
+    void refreshToken_invalidToken_throwsException() {
+        when(jwtService.extractUserName(REFRESH_TOKEN)).thenReturn(USERNAME);
+        when(userService.userDetailsService()).thenReturn(userDetailsService);
+        when(userDetailsService.loadUserByUsername(USERNAME)).thenReturn(testUser);
+        when(jwtService.isTokenValid(REFRESH_TOKEN, testUser)).thenReturn(false);
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> authenticationService.refreshToken(REFRESH_TOKEN));
+
+        assertEquals("Невалидный refresh-токен", thrown.getMessage());
+    }
+}

--- a/api-gateway/src/test/java/ru/mentor/services/impl/JwtServiceImplTest.java
+++ b/api-gateway/src/test/java/ru/mentor/services/impl/JwtServiceImplTest.java
@@ -1,0 +1,78 @@
+package ru.mentor.services.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import ru.mentor.constant.Role;
+import ru.mentor.entity.UserEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class JwtServiceImplTest {
+
+    private static final String JWT_SIGNING_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    private static final Long ACCESS_EXPIRATION_MINUTES = 15L;
+    private static final Long REFRESH_EXPIRATION_DAYS = 7L;
+
+    private JwtServiceImpl jwtService;
+    private UserEntity currentUser;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = new JwtServiceImpl();
+        ReflectionTestUtils.setField(jwtService, "jwtSigningKey", JWT_SIGNING_KEY);
+        ReflectionTestUtils.setField(jwtService, "accessExpirationMinutes", ACCESS_EXPIRATION_MINUTES);
+        ReflectionTestUtils.setField(jwtService, "refreshExpirationDays", REFRESH_EXPIRATION_DAYS);
+
+        currentUser = UserEntity.builder()
+                .id(1L)
+                .username("user@test")
+                .role(Role.MENTOR)
+                .build();
+    }
+
+    @Test
+    void extractUserName_validToken_returnsUsername() {
+        String token = jwtService.generateToken(currentUser);
+        String userName = jwtService.extractUserName(token);
+        assertEquals(currentUser.getUsername(), userName);
+    }
+
+    @Test
+    void generateToken_userDetails_returnsValidToken() {
+        String token = jwtService.generateToken(currentUser);
+        assertNotNull(token);
+        assertFalse(token.isBlank());
+        assertEquals(currentUser.getUsername(), jwtService.extractUserName(token));
+    }
+
+    @Test
+    void generateRefreshToken_userDetails_returnsValidToken() {
+        String token = jwtService.generateRefreshToken(currentUser);
+        assertNotNull(token);
+        assertFalse(token.isBlank());
+        assertEquals(currentUser.getUsername(), jwtService.extractUserName(token));
+    }
+
+    @Test
+    void isTokenValid_sameUser_returnsTrue() {
+        String token = jwtService.generateToken(currentUser);
+        boolean valid = jwtService.isTokenValid(token, currentUser);
+        assertTrue(valid);
+    }
+
+    @Test
+    void isTokenValid_differentUser_returnsFalse() {
+        String token = jwtService.generateToken(currentUser);
+        UserEntity otherUser = UserEntity.builder()
+                .id(2L)
+                .username("other@test")
+                .role(Role.MENTOR)
+                .build();
+        boolean valid = jwtService.isTokenValid(token, otherUser);
+        assertFalse(valid);
+    }
+}

--- a/api-gateway/src/test/java/ru/mentor/services/impl/RedirectAccessServiceImplTest.java
+++ b/api-gateway/src/test/java/ru/mentor/services/impl/RedirectAccessServiceImplTest.java
@@ -1,0 +1,158 @@
+package ru.mentor.services.impl;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import ru.mentor.constant.Role;
+import ru.mentor.dto.GetAccessRequest;
+import ru.mentor.dto.front.CourseAccessRequest;
+import ru.mentor.dto.front.ModuleAccessRequest;
+import ru.mentor.entity.UserEntity;
+import ru.mentor.feign.MentorClient;
+import ru.mentor.mapper.AccessMapper;
+import ru.mentor.services.UserService;
+
+@ExtendWith(MockitoExtension.class)
+class RedirectAccessServiceImplTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private AccessMapper accessMapper;
+
+    @Mock
+    private MentorClient mentorClient;
+
+    @InjectMocks
+    private RedirectAccessServiceImpl redirectAccessService;
+
+    private static final Long USER_ID = 1L;
+    private static final Long COURSE_ID = 10L;
+    private static final Long MODULE_ID = 20L;
+
+    private UserEntity currentUser;
+
+    @BeforeEach
+    void setUp() {
+        currentUser = UserEntity.builder()
+                .id(USER_ID)
+                .username("mentor@test")
+                .role(Role.MENTOR)
+                .build();
+    }
+
+    @Test
+    void giveCourseAccess_delegatesToMentorClient_returnsResponse() {
+        CourseAccessRequest request = new CourseAccessRequest();
+        request.setUserId(USER_ID);
+        request.setCourseId(COURSE_ID);
+
+        GetAccessRequest innerRequest = GetAccessRequest.builder()
+                .mentorId(currentUser.getId())
+                .userId(USER_ID)
+                .courseId(COURSE_ID)
+                .moduleId(null)
+                .build();
+
+        Mockito.when(userService.getCurrentUser()).thenReturn(currentUser);
+        Mockito.when(accessMapper.mapToGetAccessRequest(currentUser, request)).thenReturn(innerRequest);
+        Mockito.when(mentorClient.giveCourseAccess(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.any(GetAccessRequest.class)
+                )).thenReturn(ResponseEntity.ok().build());
+
+        ResponseEntity<?> result = redirectAccessService.giveCourseAccess(request);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(HttpStatus.OK, result.getStatusCode());
+    }
+
+    @Test
+    void revokeCourseAccess_delegatesToMentorClient_returnsResponse() {
+        CourseAccessRequest request = new CourseAccessRequest();
+        request.setUserId(USER_ID);
+        request.setCourseId(COURSE_ID);
+
+        GetAccessRequest innerRequest = GetAccessRequest.builder()
+                .mentorId(currentUser.getId())
+                .userId(USER_ID)
+                .courseId(COURSE_ID)
+                .moduleId(null)
+                .build();
+
+        Mockito.when(userService.getCurrentUser()).thenReturn(currentUser);
+        Mockito.when(accessMapper.mapToGetAccessRequest(currentUser, request)).thenReturn(innerRequest);
+        Mockito.when(mentorClient.revokeCourseAccess(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.any(GetAccessRequest.class)
+        )).thenReturn(ResponseEntity.ok().build());
+
+        ResponseEntity<?> result = redirectAccessService.revokeCourseAccess(request);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(HttpStatus.OK, result.getStatusCode());
+    }
+
+    @Test
+    void giveModuleAccess_delegatesToMentorClient_returnsResponse() {
+        ModuleAccessRequest request = new ModuleAccessRequest();
+        request.setUserId(USER_ID);
+        request.setCourseId(COURSE_ID);
+        request.setModuleId(MODULE_ID);
+
+        GetAccessRequest innerRequest = GetAccessRequest.builder()
+                .mentorId(currentUser.getId())
+                .userId(USER_ID)
+                .courseId(COURSE_ID)
+                .moduleId(MODULE_ID)
+                .build();
+
+        Mockito.when(userService.getCurrentUser()).thenReturn(currentUser);
+        Mockito.when(accessMapper.mapToGetAccessRequest(currentUser, request)).thenReturn(innerRequest);
+        Mockito.when(mentorClient.giveModuleAccess(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.any(GetAccessRequest.class)
+        )).thenReturn(ResponseEntity.ok().build());
+
+        ResponseEntity<?> result = redirectAccessService.giveModuleAccess(request);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(HttpStatus.OK, result.getStatusCode());
+    }
+
+    @Test
+    void revokeModuleAccess_delegatesToMentorClient_returnsResponse() {
+        ModuleAccessRequest request = new ModuleAccessRequest();
+        request.setUserId(USER_ID);
+        request.setCourseId(COURSE_ID);
+        request.setModuleId(MODULE_ID);
+
+        GetAccessRequest innerRequest = GetAccessRequest.builder()
+                .mentorId(currentUser.getId())
+                .userId(USER_ID)
+                .courseId(COURSE_ID)
+                .moduleId(MODULE_ID)
+                .build();
+
+        Mockito.when(userService.getCurrentUser()).thenReturn(currentUser);
+        Mockito.when(accessMapper.mapToGetAccessRequest(currentUser, request)).thenReturn(innerRequest);
+        Mockito.when(mentorClient.revokeModuleAccess(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.any(GetAccessRequest.class)
+        )).thenReturn(ResponseEntity.ok().build());
+
+        ResponseEntity<?> result = redirectAccessService.revokeModuleAccess(request);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(HttpStatus.OK, result.getStatusCode());
+    }
+}

--- a/api-gateway/src/test/java/ru/mentor/services/impl/RedirectProgressServiceImplTest.java
+++ b/api-gateway/src/test/java/ru/mentor/services/impl/RedirectProgressServiceImplTest.java
@@ -1,0 +1,99 @@
+package ru.mentor.services.impl;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import ru.mentor.constant.Role;
+import ru.mentor.dto.CourseProgressResponse;
+import ru.mentor.dto.CourseProgressStatisticDto;
+import ru.mentor.dto.MenteeProgressDto;
+import ru.mentor.entity.UserEntity;
+import ru.mentor.feign.MentorClient;
+import ru.mentor.services.UserService;
+
+import java.util.List;
+import java.util.Map;
+
+@ExtendWith(MockitoExtension.class)
+class RedirectProgressServiceImplTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private MentorClient mentorClient;
+
+    @InjectMocks
+    private RedirectProgressServiceImpl redirectProgressService;
+
+    private static final Long COURSE_ID = 1L;
+
+    private UserEntity currentUser;
+
+    @BeforeEach
+    void setUp() {
+        currentUser = UserEntity.builder()
+                .id(1L)
+                .username("mentor@test")
+                .role(Role.MENTOR)
+                .build();
+
+    }
+
+    @Test
+    void getCourseProgressByMentor_delegatesToMentorClient_returnBody(){
+        CourseProgressResponse expected = CourseProgressResponse.builder()
+                .courseId(COURSE_ID)
+                .courseTitle("Тест курс")
+                .mentee(List.of())
+                .statistic(CourseProgressStatisticDto.builder().totalMenteeCount(0).
+                        moduleDistribution(Map.of()).build())
+                .build();
+
+        Mockito.when(userService.getCurrentUser()).thenReturn(currentUser);
+        Mockito.when(mentorClient.getCourseProgressByMentor(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.eq(currentUser.getId()),
+                ArgumentMatchers.eq(COURSE_ID)
+        )).thenReturn(ResponseEntity.ok(expected));
+
+        CourseProgressResponse result = redirectProgressService.getCourseProgressByMentor(COURSE_ID);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(COURSE_ID, result.getCourseId());
+        Assertions.assertEquals("Тест курс", result.getCourseTitle());
+
+    }
+
+    @Test
+    void getAllUsersAtCourse_delegatesToMentorClient_returnBody(){
+        List<MenteeProgressDto> expected = List.of(
+                MenteeProgressDto.builder()
+                        .userId(2L)
+                        .firstName("Влад")
+                        .lastName("Юрин")
+                        .build()
+        );
+
+        Mockito.when(userService.getCurrentUser()).thenReturn(currentUser);
+        Mockito.when(mentorClient.getAllUsersAtCourse(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.eq(currentUser.getId()),
+                ArgumentMatchers.eq(COURSE_ID)
+        )).thenReturn(ResponseEntity.ok(expected));
+
+        List<MenteeProgressDto> result = redirectProgressService.getAllUsersAtCourse(COURSE_ID);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(2L, result.getFirst().getUserId());
+
+    }
+}

--- a/api-gateway/src/test/java/ru/mentor/services/impl/UserServiceImplTest.java
+++ b/api-gateway/src/test/java/ru/mentor/services/impl/UserServiceImplTest.java
@@ -1,0 +1,160 @@
+package ru.mentor.services.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import ru.mentor.entity.UserEntity;
+import ru.mentor.exception.UserException;
+import ru.mentor.repository.UserRepository;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    private UserEntity testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = UserEntity.builder()
+                .id(1L)
+                .username("user@test")
+                .password("encoded")
+                .build();
+    }
+
+    @Test
+    void create_userDoesNotExist_savesAndReturnsUser(){
+        when(userRepository.existsByUsername(testUser.getUsername())).thenReturn(false);
+        when(userRepository.save(any(UserEntity.class))).thenReturn(testUser);
+
+        UserEntity result = userService.create(testUser);
+
+        assertNotNull(result);
+        assertEquals(testUser.getId(), result.getId());
+        assertEquals(testUser.getUsername(), result.getUsername());
+    }
+
+    @Test
+    void create_userAlreadyExists_throwsUserException() {
+        when(userRepository.existsByUsername(testUser.getUsername())).thenReturn(true);
+
+        UserException thrown = assertThrows(UserException.class,
+                () -> userService.create(testUser));
+        assertEquals(
+                String.format("Юзер с username = %s уже существует", testUser.getUsername()),
+                thrown.getMessage()
+        );
+    }
+
+    @Test
+    void existsByUserName_delegatesToRepository() {
+        String username = "user@test";
+        when(userRepository.existsByUsername(username)).thenReturn(true);
+
+        boolean result = userService.existsByUserName(username);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void getByUsername_returnsUserFromRepository() {
+        when(userRepository.findByUsernameOrThrow("user@test")).thenReturn(testUser);
+
+        UserEntity result = userService.getByUsername("user@test");
+
+        assertNotNull(result);
+        assertEquals(testUser.getId(), result.getId());
+        assertEquals(testUser.getUsername(), result.getUsername());
+
+    }
+
+    @Test
+    void userDetailsService_loadUserByUsername_returnsUser() {
+        when(userRepository.findByUsernameOrThrow("user@test")).thenReturn(testUser);
+
+        UserDetailsService userDetailsService = userService.userDetailsService();
+        UserDetails result = userDetailsService.loadUserByUsername("user@test");
+
+        assertNotNull(result);
+        assertEquals(testUser.getUsername(), result.getUsername());
+    }
+
+    @Test
+    void getCurrentUser_returnsUserFromSecurityContext() {
+        Authentication authentication = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getName()).thenReturn("user@test");
+
+        SecurityContextHolder.setContext(securityContext);
+        when(userRepository.findByUsernameOrThrow("user@test")).thenReturn(testUser);
+
+        UserEntity result = userService.getCurrentUser();
+
+        assertNotNull(result);
+        assertEquals(testUser.getId(), result.getId());
+        assertEquals(testUser.getUsername(), result.getUsername());
+    }
+
+    @Test
+    void getCurrentUserId_whenPrincipalIsUserEntity_returnsId() {
+        Authentication authentication = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(testUser);
+
+        SecurityContextHolder.setContext(securityContext);
+
+        Long result = userService.getCurrentUserId();
+
+        assertNotNull(result);
+        assertEquals(testUser.getId(), result);
+    }
+
+    @Test
+    void getCurrentUserId_whenPrincipalIsNotUserEntity_throwsException() {
+        Authentication authentication = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn("not-a-user");
+
+        SecurityContextHolder.setContext(securityContext);
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> userService.getCurrentUserId());
+
+        assertEquals("Пользователь не найден в контексте безопасности", thrown.getMessage());
+    }
+
+    @Test
+    void getUserById_returnsUserFromRepository() {
+        when(userRepository.findByIdOrThrow(1L)).thenReturn(testUser);
+
+        UserEntity result = userService.getUserById(1L);
+
+        assertNotNull(result);
+        assertEquals(testUser.getId(), result.getId());
+        assertEquals(testUser.getUsername(), result.getUsername());
+    }
+}

--- a/common-lib/src/test/java/ru/mentor/mapper/BaseMapperTest.java
+++ b/common-lib/src/test/java/ru/mentor/mapper/BaseMapperTest.java
@@ -1,0 +1,294 @@
+package ru.mentor.mapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import ru.mentor.common.GetAllModulesRequest;
+import ru.mentor.common.GrpcPageRequest;
+import ru.mentor.common.Header;
+import ru.mentor.common.PageDetails;
+import ru.mentor.constant.Role;
+import ru.mentor.dto.CourseDto;
+import ru.mentor.dto.ModuleDto;
+import ru.mentor.dto.UserInfoDto;
+import ru.mentor.entity.CourseEntity;
+import ru.mentor.entity.CourseTagEntity;
+import ru.mentor.entity.CourseTagLinkEntity;
+import ru.mentor.entity.ModuleEntity;
+import ru.mentor.entity.UserEntity;
+
+class BaseMapperTest {
+
+    private static final LocalDateTime FIXED_TIME = LocalDateTime.of(2026, 4, 2, 12, 0);
+
+    private final BaseMapper mapper = new BaseMapper();
+
+    @Test
+    void mapModule_whenContentNotNeeded_setsModuleContentNull() {
+        ModuleEntity entity = ModuleEntity.builder()
+                .id(1L)
+                .moduleTitle("A")
+                .moduleOrderNumber(1)
+                .moduleContent("secret")
+                .isActive(true)
+                .createdAt(FIXED_TIME)
+                .build();
+
+        ModuleDto dto = mapper.mapModule(entity, false);
+
+        Assertions.assertNull(dto.getModuleContent());
+        Assertions.assertEquals("A", dto.getModuleTitle());
+        Assertions.assertEquals(1, dto.getModuleOrderNumber());
+    }
+
+    @Test
+    void mapModule_whenContentNeeded_includesModuleContent() {
+        ModuleEntity entity = ModuleEntity.builder()
+                .id(1L)
+                .moduleTitle("A")
+                .moduleOrderNumber(1)
+                .moduleContent("body")
+                .isActive(true)
+                .createdAt(FIXED_TIME)
+                .build();
+
+        ModuleDto dto = mapper.mapModule(entity, true);
+
+        Assertions.assertEquals("body", dto.getModuleContent());
+    }
+
+    @Test
+    void mapModules_sortsByModuleOrderNumberAscending() {
+        ModuleEntity second = ModuleEntity.builder()
+                .id(2L)
+                .moduleTitle("Second")
+                .moduleOrderNumber(2)
+                .moduleContent(null)
+                .isActive(true)
+                .createdAt(FIXED_TIME)
+                .build();
+        ModuleEntity first = ModuleEntity.builder()
+                .id(1L)
+                .moduleTitle("First")
+                .moduleOrderNumber(1)
+                .moduleContent(null)
+                .isActive(true)
+                .createdAt(FIXED_TIME)
+                .build();
+
+        List<ModuleDto> result = mapper.mapModules(List.of(second, first), false);
+
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertEquals(1, result.get(0).getModuleOrderNumber());
+        Assertions.assertEquals(2, result.get(1).getModuleOrderNumber());
+    }
+
+    @Test
+    void mapCourse_whenAuthorNull_authorInDtoNull() {
+        CourseEntity course = CourseEntity.builder()
+                .id(10L)
+                .courseTitle("Title")
+                .description("Desc")
+                .isActive(true)
+                .createdAt(FIXED_TIME)
+                .author(null)
+                .modules(List.of())
+                .courseTags(List.of())
+                .build();
+
+        CourseDto dto = mapper.mapCourse(course, null, false, false, false);
+
+        Assertions.assertNull(dto.getAuthor());
+        Assertions.assertNull(dto.getModules());
+        Assertions.assertNull(dto.getTags());
+    }
+
+    @Test
+    void mapCourse_whenModulesAndTagsRequested_mapsNestedLists() {
+        UserEntity author = UserEntity.builder()
+                .id(5L)
+                .username("u")
+                .password("p")
+                .role(Role.MENTOR)
+                .firstName("F")
+                .lastName("L")
+                .tgNickname("@n")
+                .build();
+
+        ModuleEntity mod = ModuleEntity.builder()
+                .id(20L)
+                .moduleTitle("M")
+                .moduleOrderNumber(1)
+                .moduleContent("c")
+                .isActive(true)
+                .createdAt(FIXED_TIME)
+                .build();
+
+        CourseTagEntity tag = CourseTagEntity.builder()
+                .id(3L)
+                .tagName("java")
+                .isActive(true)
+                .createdAt(FIXED_TIME)
+                .build();
+        CourseTagLinkEntity link = CourseTagLinkEntity.builder()
+                .id(100L)
+                .tag(tag)
+                .createdAt(FIXED_TIME)
+                .build();
+
+        CourseEntity course = CourseEntity.builder()
+                .id(10L)
+                .courseTitle("Title")
+                .description("Desc")
+                .isActive(true)
+                .createdAt(FIXED_TIME)
+                .author(author)
+                .modules(List.of(mod))
+                .courseTags(List.of(link))
+                .build();
+
+        CourseDto dto = mapper.mapCourse(course, author, true, true, true);
+
+        Assertions.assertEquals("Title", dto.getCourseTitle());
+        Assertions.assertNotNull(dto.getAuthor());
+        Assertions.assertEquals(5L, dto.getAuthor().getId());
+        Assertions.assertEquals(1, dto.getModules().size());
+        Assertions.assertEquals("c", dto.getModules().get(0).getModuleContent());
+        Assertions.assertEquals(1, dto.getTags().size());
+        Assertions.assertEquals("java", dto.getTags().get(0).getTagName());
+    }
+
+    @Test
+    void mapCourses_delegatesToMapCourse() {
+        UserEntity author = UserEntity.builder()
+                .id(1L)
+                .username("a")
+                .password("p")
+                .role(Role.USER)
+                .firstName("A")
+                .lastName("B")
+                .tgNickname("@a")
+                .build();
+
+        CourseEntity course = CourseEntity.builder()
+                .id(99L)
+                .courseTitle("One")
+                .description("d")
+                .isActive(true)
+                .createdAt(FIXED_TIME)
+                .author(author)
+                .modules(List.of())
+                .courseTags(List.of())
+                .build();
+
+        List<CourseDto> list = mapper.mapCourses(List.of(course), false, false, false);
+
+        Assertions.assertEquals(1, list.size());
+        Assertions.assertEquals(99L, list.get(0).getId());
+        Assertions.assertEquals(1L, list.get(0).getAuthor().getId());
+    }
+
+    @Test
+    void mapUserDto_mapsCoreFields() {
+        UserEntity entity = UserEntity.builder()
+                .id(7L)
+                .username("login")
+                .password("pw")
+                .role(Role.ADMIN)
+                .firstName("Ivan")
+                .lastName("Sidorov")
+                .tgNickname("@ivan")
+                .build();
+
+        UserInfoDto dto = mapper.mapUserDto(entity);
+
+        Assertions.assertEquals(7L, dto.getId());
+        Assertions.assertEquals("login", dto.getUsername());
+        Assertions.assertEquals(Role.ADMIN, dto.getRole());
+        Assertions.assertEquals("Ivan", dto.getFirstName());
+        Assertions.assertEquals("Sidorov", dto.getLastName());
+        Assertions.assertEquals("@ivan", dto.getTgNickname());
+    }
+
+    @Test
+    void mapUserEntity_mapsFromDtoIncludingTgChatId() {
+        UserInfoDto dto = UserInfoDto.builder()
+                .id(8L)
+                .username("x")
+                .role(Role.MENTOR)
+                .firstName("A")
+                .lastName("B")
+                .tgNickname("@x")
+                .tgChatId(12345L)
+                .build();
+
+        UserEntity entity = mapper.mapUserEntity(dto);
+
+        Assertions.assertEquals(8L, entity.getId());
+        Assertions.assertEquals("x", entity.getUsername());
+        Assertions.assertEquals(Role.MENTOR, entity.getRole());
+        Assertions.assertEquals(12345L, entity.getTgChatId());
+    }
+
+    @Test
+    void constructGrpcPageRequest_threeArgs_setsHeaderAndPaging() {
+        Header header = Header.newBuilder()
+                .setRequestId("rq")
+                .setNodeId("node")
+                .setApiKey("key")
+                .build();
+
+        GrpcPageRequest grpc = mapper.constructGrpcPageRequest(header, 3, 20);
+
+        Assertions.assertEquals(header, grpc.getHeader());
+        Assertions.assertEquals(3, grpc.getPageNumber());
+        Assertions.assertEquals(20, grpc.getPageSize());
+    }
+
+    @Test
+    void constructGrpcPageRequest_fourArgs_setsSenderId() {
+        Header header = Header.newBuilder().setRequestId("r").build();
+
+        GrpcPageRequest grpc = mapper.constructGrpcPageRequest(header, 0, 10, 42L);
+
+        Assertions.assertEquals(42L, grpc.getSenderId());
+    }
+
+    @Test
+    void mapGrpcPageDetailsToPageRequest_buildsSpringPageRequest() {
+        PageDetails details = PageDetails.newBuilder()
+                .setPage(2)
+                .setSize(15)
+                .build();
+
+        PageRequest pr = mapper.mapGrpcPageDetailsToPageRequest(details);
+
+        Assertions.assertEquals(2, pr.getPageNumber());
+        Assertions.assertEquals(15, pr.getPageSize());
+    }
+
+    @Test
+    void mapGrpcPageRequestToPageRequest_usesPageNumberAndSize() {
+        GrpcPageRequest grpc = GrpcPageRequest.newBuilder()
+                .setPageNumber(5)
+                .setPageSize(25)
+                .build();
+
+        PageRequest pr = mapper.mapGrpcPageRequestToPageRequest(grpc);
+
+        Assertions.assertEquals(5, pr.getPageNumber());
+        Assertions.assertEquals(25, pr.getPageSize());
+    }
+
+    @Test
+    void constructGetAllModulesRequest_setsCourseIdAndHeader() {
+        Header header = Header.newBuilder().setRequestId("id").build();
+
+        GetAllModulesRequest req = mapper.constructGetAllModulesRequest(header, 77L);
+
+        Assertions.assertEquals(header, req.getHeader());
+        Assertions.assertEquals(77L, req.getCourseId());
+    }
+}

--- a/common-lib/src/test/java/ru/mentor/mapper/KafkaMapperTest.java
+++ b/common-lib/src/test/java/ru/mentor/mapper/KafkaMapperTest.java
@@ -1,36 +1,61 @@
 package ru.mentor.mapper;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import ru.mentor.constant.CalendarSlotMeetingType;
-import ru.mentor.constant.CalendarSlotType;
+import ru.mentor.constant.NotificationDestination;
+import ru.mentor.constant.NotificationStatus;
 import ru.mentor.constant.NotificationTypeEnum;
+import ru.mentor.constant.Role;
 import ru.mentor.dto.UserInfoDto;
+import ru.mentor.dto.kafka.CourseAccessGrantedNotificationPayload;
+import ru.mentor.dto.kafka.CourseAccessRevokedNotificationPayload;
+import ru.mentor.dto.kafka.CourseCreatedMentorNotificationPayload;
+import ru.mentor.dto.kafka.CourseDeletedMentorNotificationPayload;
 import ru.mentor.dto.kafka.KafkaNotificationDto;
+import ru.mentor.dto.kafka.MentorReminderNotificationPayload;
+import ru.mentor.dto.kafka.ModuleAccessGrantedNotificationPayload;
+import ru.mentor.dto.kafka.ModuleAccessRevokedNotificationPayload;
+import ru.mentor.dto.kafka.ModuleCreatedMentorNotificationPayload;
+import ru.mentor.dto.kafka.ModuleDeletedMentorNotificationPayload;
 import ru.mentor.dto.kafka.NotificationPayload;
+import ru.mentor.dto.kafka.SlotBookedNotificationPayload;
 import ru.mentor.dto.kafka.StudentReminderNotificationPayload;
+import ru.mentor.dto.kafka.UserRegistrationNotificationPayload;
 import ru.mentor.entity.MentorTimeSlotEntity;
+import ru.mentor.entity.NotificationEntity;
 import ru.mentor.entity.UserEntity;
 import ru.mentor.testUtil.TestDataGenerator;
 
-import java.util.Set;
-
 class KafkaMapperTest {
 
+    private static final LocalDateTime FIXED = LocalDateTime.of(2026, 4, 2, 18, 0);
+
     private KafkaMapper kafkaMapper;
-    private BaseMapper baseMapper;
 
     @BeforeEach
     void setUp() {
         kafkaMapper = new KafkaMapper();
-        baseMapper = new BaseMapper();
+    }
+
+    private static UserInfoDto sampleUser() {
+        return UserInfoDto.builder()
+                .id(1L)
+                .username("mentor")
+                .role(Role.MENTOR)
+                .firstName("F")
+                .lastName("L")
+                .tgNickname("@m")
+                .build();
     }
 
     @Test
     void createKafkaNotificationDto_validData_success() {
         NotificationTypeEnum notificationType = NotificationTypeEnum.STUDENT_CALENDAR_SLOT_REMINDER;
-        UserInfoDto userInfoDto = baseMapper.mapUserDto(TestDataGenerator.getTestParticipantUser());
+        UserInfoDto userInfoDto = sampleUser();
         NotificationPayload payload = new NotificationPayload() {};
 
         KafkaNotificationDto result = kafkaMapper.createKafkaNotificationDto(notificationType,
@@ -42,19 +67,166 @@ class KafkaMapperTest {
     }
 
     @Test
-    void createStudentReminderNotificationPayload() {
+    void createCourseAccessGrantedNotificationPayload_mapsFields() {
+        UserInfoDto by = sampleUser();
+
+        CourseAccessGrantedNotificationPayload p =
+                kafkaMapper.createCourseAccessGrantedNotificationPayload("Course A", FIXED, by);
+
+        Assertions.assertEquals("Course A", p.getCourseTitle());
+        Assertions.assertEquals(FIXED, p.getAccessGrantedAt());
+        Assertions.assertEquals(by, p.getAccessGrantedBy());
+    }
+
+    @Test
+    void createCourseAccessRevokedNotificationPayload_mapsFields() {
+        UserInfoDto by = sampleUser();
+
+        CourseAccessRevokedNotificationPayload p =
+                kafkaMapper.createCourseAccessRevokedNotificationPayload("Course B", FIXED, by);
+
+        Assertions.assertEquals("Course B", p.getCourseTitle());
+        Assertions.assertEquals(FIXED, p.getAccessRevokedAt());
+        Assertions.assertEquals(by, p.getAccessRevokedBy());
+    }
+
+    @Test
+    void courseCreatedMentorNotificationPayload_mapsFields() {
+        UserInfoDto by = sampleUser();
+
+        CourseCreatedMentorNotificationPayload p =
+                kafkaMapper.courseCreatedMentorNotificationPayload("New", FIXED, by);
+
+        Assertions.assertEquals("New", p.getCourseTitle());
+        Assertions.assertEquals(FIXED, p.getCreatedAt());
+        Assertions.assertEquals(by, p.getCourseCreatedBy());
+    }
+
+    @Test
+    void courseDeletedMentorNotificationPayload_mapsTitle() {
+        CourseDeletedMentorNotificationPayload p =
+                kafkaMapper.courseDeletedMentorNotificationPayload("Old");
+
+        Assertions.assertEquals("Old", p.getCourseTitle());
+    }
+
+    @Test
+    void createModuleAccessGrantedNotificationPayload_mapsFields() {
+        UserInfoDto by = sampleUser();
+
+        ModuleAccessGrantedNotificationPayload p =
+                kafkaMapper.createModuleAccessGrantedNotificationPayload("C", "M", FIXED, by);
+
+        Assertions.assertEquals("C", p.getCourseTitle());
+        Assertions.assertEquals("M", p.getModuleTitle());
+        Assertions.assertEquals(FIXED, p.getAccessGrantedAt());
+        Assertions.assertEquals(by, p.getAccessGrantedBy());
+    }
+
+    @Test
+    void createModuleAccessRevokedNotificationPayload_mapsFields() {
+        UserInfoDto by = sampleUser();
+
+        ModuleAccessRevokedNotificationPayload p =
+                kafkaMapper.createModuleAccessRevokedNotificationPayload("C", "M", FIXED, by);
+
+        Assertions.assertEquals("C", p.getCourseTitle());
+        Assertions.assertEquals("M", p.getModuleTitle());
+        Assertions.assertEquals(FIXED, p.getAccessRevokedAt());
+        Assertions.assertEquals(by, p.getAccessRevokedBy());
+    }
+
+    @Test
+    void moduleCreatedMentorNotificationPayload_mapsFields() {
+        UserInfoDto by = sampleUser();
+
+        ModuleCreatedMentorNotificationPayload p =
+                kafkaMapper.moduleCreatedMentorNotificationPayload("C", "M", FIXED, by);
+
+        Assertions.assertEquals("C", p.getCourseTitle());
+        Assertions.assertEquals("M", p.getModuleTitle());
+        Assertions.assertEquals(FIXED, p.getCreatedAt());
+        Assertions.assertEquals(by, p.getModuleCreatedBy());
+    }
+
+    @Test
+    void moduleDeletedMentorNotificationPayload_mapsTitles() {
+        ModuleDeletedMentorNotificationPayload p =
+                kafkaMapper.moduleDeletedMentorNotificationPayload("C", "M");
+
+        Assertions.assertEquals("C", p.getCourseTitle());
+        Assertions.assertEquals("M", p.getModuleTitle());
+    }
+
+    @Test
+    void userRegistrationNotificationPayload_setsUserInfoAndCreatedAt() {
+        UserInfoDto user = sampleUser();
+
+        UserRegistrationNotificationPayload p = kafkaMapper.userRegistrationNotificationPayload(user);
+
+        Assertions.assertEquals(user, p.getUserInfo());
+        Assertions.assertNotNull(p.getCreatedAt());
+    }
+
+    @Test
+    void mapNotificationEntity_buildsEntityFromDto() {
+        KafkaNotificationDto dto = KafkaNotificationDto.builder()
+                .notificationType(NotificationTypeEnum.COURSE_ACCESS_GRANTED)
+                .build();
+        UserEntity recipient = TestDataGenerator.getTestParticipantUser();
+
+        NotificationEntity entity = kafkaMapper.mapNotificationEntity(
+                dto,
+                NotificationDestination.MAIL,
+                "err",
+                NotificationStatus.OK,
+                recipient);
+
+        Assertions.assertEquals(NotificationTypeEnum.COURSE_ACCESS_GRANTED, entity.getNotificationType());
+        Assertions.assertEquals(recipient, entity.getRecipient());
+        Assertions.assertEquals(NotificationDestination.MAIL, entity.getNotificationDestination());
+        Assertions.assertEquals(NotificationStatus.OK, entity.getNotificationStatus());
+    }
+
+    @Test
+    void slotBookedNotificationPayload_mapsTimesAndMentee() {
+        UserInfoDto mentee = sampleUser();
+        LocalDateTime start = LocalDateTime.of(2026, 5, 1, 10, 0);
+        LocalDateTime end = LocalDateTime.of(2026, 5, 1, 11, 0);
+
+        SlotBookedNotificationPayload p =
+                kafkaMapper.slotBookedNotificationPayload(start, end, mentee);
+
+        Assertions.assertEquals(start, p.getStartAt());
+        Assertions.assertEquals(end, p.getEndAt());
+        Assertions.assertEquals(mentee, p.getMentee());
+    }
+
+    @Test
+    void createStudentReminderNotificationPayload_mapsFromSlot() {
         UserEntity student = TestDataGenerator.getTestParticipantUser();
-        MentorTimeSlotEntity mentorTimeSlotEntity = TestDataGenerator.createTestSlot(1L, Set.of(student), true);
+        MentorTimeSlotEntity slot = TestDataGenerator.createTestSlot(1L, Set.of(student), true);
 
         StudentReminderNotificationPayload result =
-                kafkaMapper.createStudentReminderNotificationPayload(mentorTimeSlotEntity, student);
+                kafkaMapper.createStudentReminderNotificationPayload(slot, student);
 
         Assertions.assertEquals(TestDataGenerator.TEST_USER_FIRST_NAME, result.getStudentName());
         Assertions.assertEquals(TestDataGenerator.DEFAULT_START_TIME, result.getCalendarSlotTime());
         Assertions.assertEquals(TestDataGenerator.TEST_MENTOR_FIRST_NAME, result.getMentorName());
-        Assertions.assertEquals(CalendarSlotMeetingType.COMMUNICATION.toString(), result.getSlotMeetingType());
-        Assertions.assertEquals(CalendarSlotType.INDIVIDUAL.toString(), result.getSlotType());
-        Assertions.assertEquals(TestDataGenerator.TEST_DESCRIPTION, result.getDescription());
-        Assertions.assertEquals(TestDataGenerator.TEST_LINK, result.getMeetingLink());
+    }
+
+    @Test
+    void createMentorReminderNotificationPayload_collectsParticipantFirstNames() {
+        UserEntity u1 = TestDataGenerator.getTestParticipantUser();
+        UserEntity u2 = TestDataGenerator.getAnotherTestParticipantUser();
+        MentorTimeSlotEntity slot = TestDataGenerator.createTestSlot(2L, Set.of(u1, u2), true);
+
+        MentorReminderNotificationPayload p = kafkaMapper.createMentorReminderNotificationPayload(slot);
+
+        Assertions.assertEquals(TestDataGenerator.TEST_MENTOR_FIRST_NAME, p.getMentorName());
+        List<String> names = p.getStudentNames();
+        Assertions.assertEquals(2, names.size());
+        Assertions.assertTrue(names.contains(TestDataGenerator.TEST_USER_FIRST_NAME));
+        Assertions.assertTrue(names.contains("Ivan"));
     }
 }

--- a/common-lib/src/test/java/ru/mentor/mapper/ProtoTimeMapperTest.java
+++ b/common-lib/src/test/java/ru/mentor/mapper/ProtoTimeMapperTest.java
@@ -1,0 +1,38 @@
+package ru.mentor.mapper;
+
+import com.google.protobuf.Timestamp;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ProtoTimeMapperTest {
+
+    private final ProtoTimeMapper mapper = new ProtoTimeMapper();
+
+    @Test
+    void toLocalDateTime_null_returnsNull() {
+        Assertions.assertNull(mapper.toLocalDateTime(null));
+    }
+
+    @Test
+    void toTimestamp_null_returnsNull() {
+        Assertions.assertNull(mapper.toTimestamp(null));
+    }
+
+    @Test
+    void toLocalDateTime_and_toTimestamp_roundTrip_preservesUtcInstant() {
+        LocalDateTime original = LocalDateTime.of(2026, 4, 2, 18, 45, 30, 123_456_789);
+        Timestamp proto = mapper.toTimestamp(original);
+        LocalDateTime back = mapper.toLocalDateTime(proto);
+        Assertions.assertEquals(original, back);
+    }
+
+    @Test
+    void toLocalDateTime_epochBoundary_convertsToUtc() {
+        Timestamp ts = Timestamp.newBuilder().setSeconds(1_700_000_000L).setNanos(500_000_000).build();
+        LocalDateTime ldt = mapper.toLocalDateTime(ts);
+        Timestamp again = mapper.toTimestamp(ldt);
+        Assertions.assertEquals(ts.getSeconds(), again.getSeconds());
+        Assertions.assertEquals(ts.getNanos(), again.getNanos());
+    }
+}

--- a/common-lib/src/test/java/ru/mentor/mapper/UserMapperTest.java
+++ b/common-lib/src/test/java/ru/mentor/mapper/UserMapperTest.java
@@ -1,0 +1,56 @@
+package ru.mentor.mapper;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import ru.mentor.common.AuthorResponse;
+import ru.mentor.constant.Role;
+import ru.mentor.dto.UserInfoDto;
+import ru.mentor.entity.UserEntity;
+
+class UserMapperTest {
+
+    private final UserMapper mapper = new UserMapper();
+
+    @Test
+    void mapGrpcAuthorResponseToUserInfoDto_mapsFields_andSetsMentorRole() {
+        AuthorResponse author = AuthorResponse.newBuilder()
+                .setUserId(42L)
+                .setUsername("mentor1")
+                .setFirstName("Ivan")
+                .setLastName("Petrov")
+                .setTgNickname("@ivan")
+                .setTgChatId(99L)
+                .build();
+
+        UserInfoDto dto = mapper.mapGrpcAuthorResponseToUserInfoDto(author);
+
+        Assertions.assertEquals(42L, dto.getId());
+        Assertions.assertEquals("mentor1", dto.getUsername());
+        Assertions.assertEquals(Role.MENTOR, dto.getRole());
+        Assertions.assertEquals("Ivan", dto.getFirstName());
+        Assertions.assertEquals("Petrov", dto.getLastName());
+        Assertions.assertEquals("@ivan", dto.getTgNickname());
+        Assertions.assertEquals(99L, dto.getTgChatId());
+    }
+
+    @Test
+    void mapUserEntityToCourseAuthorResponse_mapsAllFields() {
+        UserEntity user = UserEntity.builder()
+                .id(10L)
+                .username("author")
+                .firstName("Ada")
+                .lastName("Lovelace")
+                .tgNickname("@ada")
+                .tgChatId(777L)
+                .build();
+
+        AuthorResponse response = mapper.mapUserEntityToCourseAuthorResponse(user);
+
+        Assertions.assertEquals(10L, response.getUserId());
+        Assertions.assertEquals("author", response.getUsername());
+        Assertions.assertEquals("Ada", response.getFirstName());
+        Assertions.assertEquals("Lovelace", response.getLastName());
+        Assertions.assertEquals("@ada", response.getTgNickname());
+        Assertions.assertEquals(777L, response.getTgChatId());
+    }
+}

--- a/common-lib/src/test/java/ru/mentor/mapper/UtilMapperTest.java
+++ b/common-lib/src/test/java/ru/mentor/mapper/UtilMapperTest.java
@@ -1,0 +1,78 @@
+package ru.mentor.mapper;
+
+import com.google.protobuf.Timestamp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import ru.mentor.common.Role;
+import ru.mentor.common.SlotMeetingType;
+import ru.mentor.common.SlotType;
+import ru.mentor.common.UserInfo;
+import ru.mentor.constant.CalendarSlotMeetingType;
+import ru.mentor.constant.CalendarSlotType;
+import ru.mentor.entity.UserEntity;
+
+import java.time.LocalDateTime;
+
+public class UtilMapperTest {
+    @Test
+    void userEntityRoleToUserInfoRole_mentorRole_returnsProtoMentorRole() {
+        UserEntity userEntity = UserEntity.builder()
+                .role(ru.mentor.constant.Role.MENTOR)
+                .build();
+
+        ru.mentor.common.Role result = UtilMapper.userEntityRoleToUserInfoRole(userEntity);
+        Assertions.assertEquals(ru.mentor.common.Role.MENTOR,result);
+    }
+
+    @Test
+    void userInfoRoleToUserInfoDtoRole_adminRole_returnsConstantAdminRole() {
+        UserInfo userInfo = UserInfo.newBuilder()
+                .setId(1L)
+                .setUsername("user@test")
+                .setRole(Role.ADMIN)
+                .setFirstName("First")
+                .setLastName("Last")
+                .setTgNickname("@nick")
+                .build();
+
+        ru.mentor.constant.Role result = UtilMapper.userInfoRoleToUserInfoDtoRole(userInfo);
+
+        Assertions.assertEquals(ru.mentor.constant.Role.ADMIN, result);
+    }
+
+    @Test
+    void timestampToLocalDateTime_timestampNotNull_convertsCorrectly() {
+        LocalDateTime source = LocalDateTime.of(2026, 4, 2, 18, 0, 0);
+        Timestamp timestamp = UtilMapper.buildTimestamp(source);
+        LocalDateTime result = UtilMapper.timestampToLocalDateTime(timestamp);
+        Assertions.assertEquals(source, result);
+    }
+
+    @Test
+    void calendarSlotTypeToSlotType_individual_matchesProtoEnum() {
+        Assertions.assertEquals(
+                SlotType.INDIVIDUAL,
+                UtilMapper.calendarSlotTypeToSlotType(CalendarSlotType.INDIVIDUAL));
+    }
+
+    @Test
+    void slotTypeToCalendarSlotType_roundTrip() {
+        Assertions.assertEquals(
+                CalendarSlotType.GROUP,
+                UtilMapper.slotTypeToCalendarSlotType(SlotType.GROUP));
+    }
+
+    @Test
+    void calendarSlotMeetingTypeToSlotMeetingType_communication_matchesProto() {
+        Assertions.assertEquals(
+                SlotMeetingType.COMMUNICATION,
+                UtilMapper.calendarSlotMeetingTypeToSlotMeetingType(CalendarSlotMeetingType.COMMUNICATION));
+    }
+
+    @Test
+    void slotMeetingTypeToCalendarSlotMeetingType_roundTrip() {
+        Assertions.assertEquals(
+                CalendarSlotMeetingType.COMMUNICATION,
+                UtilMapper.slotMeetingTypeToCalendarSlotMeetingType(SlotMeetingType.COMMUNICATION));
+    }
+}

--- a/common-lib/src/test/java/ru/mentor/validation/MarkdownFileValidatorTest.java
+++ b/common-lib/src/test/java/ru/mentor/validation/MarkdownFileValidatorTest.java
@@ -1,0 +1,167 @@
+package ru.mentor.validation;
+
+import jakarta.validation.Payload;
+import java.lang.annotation.Annotation;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+class MarkdownFileValidatorTest {
+
+    private final MarkdownFileValidator validator = new MarkdownFileValidator();
+
+    @BeforeEach
+    void setUp() {
+        validator.initialize(defaultAnnotation());
+    }
+
+    @Test
+    void isValid_validMdFile_returnsTrue() {
+        MultipartFile file = new MockMultipartFile(
+                "file",
+                "notes.md",
+                "text/markdown",
+                "# Title".getBytes(StandardCharsets.UTF_8));
+
+        boolean ok = validator.isValid(file, Mockito.mock(jakarta.validation.ConstraintValidatorContext.class));
+
+        Assertions.assertTrue(ok);
+    }
+
+    @Test
+    void isValid_nullFile_returnsFalse() {
+        ConstraintValidatorContextMock ctx = new ConstraintValidatorContextMock();
+
+        Assertions.assertFalse(validator.isValid(null, ctx.context));
+    }
+
+    @Test
+    void isValid_wrongExtension_returnsFalse() {
+        MultipartFile file = new MockMultipartFile(
+                "file",
+                "notes.txt",
+                "text/markdown",
+                "x".getBytes(StandardCharsets.UTF_8));
+
+        ConstraintValidatorContextMock ctx = new ConstraintValidatorContextMock();
+
+        Assertions.assertFalse(validator.isValid(file, ctx.context));
+    }
+
+    @Test
+    void isValid_wrongContentType_returnsFalse() {
+        MultipartFile file = new MockMultipartFile(
+                "file",
+                "notes.md",
+                "image/png",
+                "x".getBytes(StandardCharsets.UTF_8));
+
+        ConstraintValidatorContextMock ctx = new ConstraintValidatorContextMock();
+
+        Assertions.assertFalse(validator.isValid(file, ctx.context));
+    }
+
+    @Test
+    void isValid_fileTooLarge_returnsFalse() {
+        MarkdownFileValidator smallLimit = new MarkdownFileValidator();
+        smallLimit.initialize(new ValidMarkdownFile() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return ValidMarkdownFile.class;
+            }
+
+            @Override
+            public String message() {
+                return "";
+            }
+
+            @Override
+            public Class<?>[] groups() {
+                return new Class<?>[0];
+            }
+
+            @Override
+            public Class<? extends Payload>[] payload() {
+                @SuppressWarnings("unchecked")
+                Class<? extends Payload>[] p = new Class[0];
+                return p;
+            }
+
+            @Override
+            public long maxSize() {
+                return 2L;
+            }
+
+            @Override
+            public String[] allowedTypes() {
+                return new String[]{"text/markdown", "text/x-markdown", "application/octet-stream"};
+            }
+        });
+
+        MultipartFile file = new MockMultipartFile(
+                "file",
+                "big.md",
+                "text/markdown",
+                "abc".getBytes(StandardCharsets.UTF_8));
+
+        ConstraintValidatorContextMock ctx = new ConstraintValidatorContextMock();
+
+        Assertions.assertFalse(smallLimit.isValid(file, ctx.context));
+    }
+
+    private static ValidMarkdownFile defaultAnnotation() {
+        return new ValidMarkdownFile() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return ValidMarkdownFile.class;
+            }
+
+            @Override
+            public String message() {
+                return "";
+            }
+
+            @Override
+            public Class<?>[] groups() {
+                return new Class<?>[0];
+            }
+
+            @Override
+            public Class<? extends Payload>[] payload() {
+                @SuppressWarnings("unchecked")
+                Class<? extends Payload>[] p = new Class[0];
+                return p;
+            }
+
+            @Override
+            public long maxSize() {
+                return 5L * 1024 * 1024;
+            }
+
+            @Override
+            public String[] allowedTypes() {
+                return new String[]{"text/markdown", "text/x-markdown", "application/octet-stream"};
+            }
+        };
+    }
+
+    /**
+     * Minimal mock so {@link MarkdownFileValidator} can add violations on failure paths.
+     */
+    private static final class ConstraintValidatorContextMock {
+        private final jakarta.validation.ConstraintValidatorContext context =
+                Mockito.mock(jakarta.validation.ConstraintValidatorContext.class);
+
+        private ConstraintValidatorContextMock() {
+            jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder builder =
+                    Mockito.mock(jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder.class);
+            Mockito.when(context.buildConstraintViolationWithTemplate(Mockito.anyString())).thenReturn(builder);
+            Mockito.when(builder.addConstraintViolation()).thenReturn(null);
+            Mockito.doNothing().when(context).disableDefaultConstraintViolation();
+        }
+    }
+}

--- a/mentor-service/src/test/java/ru/mentor/service/impl/AccessServiceImplTest.java
+++ b/mentor-service/src/test/java/ru/mentor/service/impl/AccessServiceImplTest.java
@@ -1,0 +1,394 @@
+package ru.mentor.service.impl;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.mentor.constant.Role;
+import ru.mentor.dto.GetAccessRequest;
+import ru.mentor.entity.*;
+import ru.mentor.exception.CustomAccessDeniedException;
+import ru.mentor.exception.EntityAlreadyExistsException;
+import ru.mentor.exception.EntityNotFoundException;
+import ru.mentor.kafka.KafkaFacade;
+import ru.mentor.repository.*;
+import ru.mentor.testUtil.TestEntityStubGenerator;
+import ru.mentor.util.AccessChecker;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+class AccessServiceImplTest {
+
+    @Mock
+    private CourseRepository courseRepository;
+
+    @Mock
+    private ModuleRepository moduleRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AccessChecker accessChecker;
+
+    @Mock
+    private UserCourseAccessRepository userCourseAccessRepository;
+
+    @Mock
+    private UserModuleAccessRepository userModuleAccessRepository;
+
+    @Mock
+    private KafkaFacade kafkaFacade;
+
+    @InjectMocks
+    private AccessServiceImpl accessService;
+
+    private static final String REQUEST_ID = "req-1";
+    private static final Long MENTOR_ID = 1L;
+    private static final Long USER_ID = 2L;
+    private static final Long COURSE_ID = 1L;
+
+    private UserEntity mentor;
+    private UserEntity user;
+    private CourseEntity course;
+    private GetAccessRequest requestCourseOnly;
+
+    @BeforeEach
+    void setUp() {
+        mentor = TestEntityStubGenerator.constructUserEntityWithRole(Role.MENTOR);
+        user = UserEntity.builder()
+                .id(USER_ID)
+                .username("студент@test")
+                .firstName("Брэд")
+                .lastName("Пит")
+                .role(Role.USER)
+                .build();
+        course = TestEntityStubGenerator.constructCourseEntity();
+        course.setAuthor(mentor);
+        requestCourseOnly = GetAccessRequest.builder()
+                .mentorId(MENTOR_ID)
+                .userId(USER_ID)
+                .courseId(COURSE_ID)
+                .build();
+    }
+
+    @Test
+    void getCourseAccessToUser_userHasNoAccess_savesAccessAndSendsKafkaMessage() {
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(userRepository.findByIdOrThrow(USER_ID)).thenReturn(user);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+        Mockito.when(accessChecker.hasAccessToCourse(USER_ID, COURSE_ID)).thenReturn(false);
+
+        UserCourseAccessEntity savedAccess = UserCourseAccessEntity.builder()
+                .id(1L)
+                .user(user)
+                .course(course)
+                .accessGrantedBy(mentor)
+                .build();
+
+        Mockito.when(userCourseAccessRepository.save(ArgumentMatchers.any(UserCourseAccessEntity.class)))
+                .thenReturn(savedAccess);
+
+        accessService.getCourseAccessToUser(REQUEST_ID, requestCourseOnly);
+        Mockito.verify(userCourseAccessRepository, Mockito.times(1))
+                .save(ArgumentMatchers.any(UserCourseAccessEntity.class));
+        Mockito.verify(kafkaFacade, Mockito.times(1))
+                .sendCourseAccessGrantedMessage(
+                        ArgumentMatchers.any(UserEntity.class),
+                        ArgumentMatchers.any(UserEntity.class),
+                        ArgumentMatchers.any(CourseEntity.class),
+                        ArgumentMatchers.any(UserCourseAccessEntity.class)
+                );
+    }
+
+    @Test
+    void getCourseAccessToUser_userAlreadyHasAccess_throwsEntityAlreadyExistsException() {
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(userRepository.findByIdOrThrow(USER_ID)).thenReturn(user);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+        Mockito.when(accessChecker.hasAccessToCourse(USER_ID, COURSE_ID)).thenReturn(true);
+
+        Assertions.assertThrows(EntityAlreadyExistsException.class,
+                () -> accessService.getCourseAccessToUser(REQUEST_ID, requestCourseOnly));
+
+        Mockito.verify(userCourseAccessRepository, Mockito.never()).save(ArgumentMatchers.any(UserCourseAccessEntity.class));
+        Mockito.verifyNoInteractions(kafkaFacade);
+    }
+
+    @Test
+    void getModuleAccessToUser_userHasCourseAccessAndNoModuleAccess_savesAccessAndSendsKafkaMessage() {
+        ModuleEntity module = TestEntityStubGenerator.constructModuleEntity();
+        module.setCourse(course);
+        Long moduleId = module.getId();
+        GetAccessRequest request = GetAccessRequest.builder()
+                .mentorId(MENTOR_ID)
+                .userId(USER_ID)
+                .courseId(COURSE_ID)
+                .moduleId(moduleId)
+                .build();
+
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(userRepository.findByIdOrThrow(USER_ID)).thenReturn(user);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+        Mockito.when(moduleRepository.findByIdOrThrow(moduleId)).thenReturn(module);
+
+        Mockito.when(accessChecker.hasAccessToModule(USER_ID, moduleId)).thenReturn(false);
+        Mockito.when(accessChecker.hasAccessToCourse(USER_ID, COURSE_ID)).thenReturn(true);
+
+        UserModuleAccessEntity savedModuleAccess = UserModuleAccessEntity.builder()
+                .id(1L)
+                .user(user)
+                .course(course)
+                .module(module)
+                .accessGrantedBy(mentor)
+                .build();
+        Mockito.when(userModuleAccessRepository.save(ArgumentMatchers.any(UserModuleAccessEntity.class)))
+                .thenReturn(savedModuleAccess);
+
+        accessService.getModuleAccessToUser(REQUEST_ID, request);
+
+        Mockito.verify(userModuleAccessRepository, Mockito.times(1))
+                .save(ArgumentMatchers.any(UserModuleAccessEntity.class));
+        Mockito.verify(kafkaFacade, Mockito.times(1))
+                .sendModuleAccessGrantedMessage(
+                        ArgumentMatchers.any(UserEntity.class),
+                        ArgumentMatchers.any(UserEntity.class),
+                        ArgumentMatchers.any(CourseEntity.class),
+                        ArgumentMatchers.any(ModuleEntity.class),
+                        ArgumentMatchers.any(UserModuleAccessEntity.class)
+                );
+    }
+
+    @Test
+    void getModuleAccessToUser_userAlreadyHasModuleAccess_throwsEntityAlreadyExistsException() {
+        ModuleEntity module = TestEntityStubGenerator.constructModuleEntity();
+        module.setCourse(course);
+        Long moduleId = module.getId();
+        GetAccessRequest request = GetAccessRequest.builder()
+                .mentorId(MENTOR_ID)
+                .userId(USER_ID)
+                .courseId(COURSE_ID)
+                .moduleId(moduleId)
+                .build();
+
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(userRepository.findByIdOrThrow(USER_ID)).thenReturn(user);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+        Mockito.when(moduleRepository.findByIdOrThrow(moduleId)).thenReturn(module);
+
+        Mockito.when(accessChecker.hasAccessToModule(USER_ID, moduleId)).thenReturn(true);
+
+        Assertions.assertThrows(EntityAlreadyExistsException.class,
+                () -> accessService.getModuleAccessToUser(REQUEST_ID, request));
+
+        Mockito.verify(userModuleAccessRepository, Mockito.never())
+                .save(ArgumentMatchers.any(UserModuleAccessEntity.class));
+        Mockito.verifyNoInteractions(kafkaFacade);
+    }
+
+    @Test
+    void getModuleAccessToUser_userHasNoCourseAccess_throwsEntityNotFoundException() {
+        ModuleEntity module = TestEntityStubGenerator.constructModuleEntity();
+        module.setCourse(course);
+        Long moduleId = module.getId();
+        GetAccessRequest request = GetAccessRequest.builder()
+                .mentorId(MENTOR_ID)
+                .userId(USER_ID)
+                .courseId(COURSE_ID)
+                .moduleId(moduleId)
+                .build();
+
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(userRepository.findByIdOrThrow(USER_ID)).thenReturn(user);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+        Mockito.when(moduleRepository.findByIdOrThrow(moduleId)).thenReturn(module);
+
+        Mockito.when(accessChecker.hasAccessToModule(USER_ID, moduleId)).thenReturn(false);
+        Mockito.when(accessChecker.hasAccessToCourse(USER_ID, COURSE_ID)).thenReturn(false);
+
+        Assertions.assertThrows(EntityNotFoundException.class,
+                () -> accessService.getModuleAccessToUser(REQUEST_ID, request));
+
+        Mockito.verify(userModuleAccessRepository, Mockito.never())
+                .save(ArgumentMatchers.any(UserModuleAccessEntity.class));
+        Mockito.verifyNoInteractions(kafkaFacade);
+    }
+
+    @Test
+    void deleteCourseAccessToUser_accessExists_deletesAndSendsKafkaMessage() {
+        UserCourseAccessEntity existingAccess = UserCourseAccessEntity.builder()
+                .id(1L)
+                .user(user)
+                .course(course)
+                .accessGrantedBy(mentor)
+                .build();
+
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(userRepository.findByIdOrThrow(USER_ID)).thenReturn(user);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+
+        Mockito.when(accessChecker.hasAccessToCourse(USER_ID, COURSE_ID)).thenReturn(true);
+
+        Mockito.when(userCourseAccessRepository.findByUserIdAndCourseId(USER_ID, COURSE_ID))
+                .thenReturn(Optional.of(existingAccess));
+
+        accessService.deleteCourseAccessToUser(REQUEST_ID, requestCourseOnly);
+
+        Mockito.verify(userCourseAccessRepository, Mockito.times(1))
+                .deleteByUserIdAndCourseId(USER_ID, COURSE_ID);
+        Mockito.verify(userModuleAccessRepository, Mockito.times(1))
+                .deleteAllByUserIdAndCourseId(USER_ID, COURSE_ID);
+        Mockito.verify(kafkaFacade, Mockito.times(1))
+                .sendCourseAccessRevokedMessage(
+                        ArgumentMatchers.any(UserEntity.class),
+                        ArgumentMatchers.any(UserEntity.class),
+                        ArgumentMatchers.any(CourseEntity.class),
+                        ArgumentMatchers.any(LocalDateTime.class)
+                );
+    }
+
+    @Test
+    void deleteCourseAccessToUser_accessNotFound_throwsEntityNotFoundException() {
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(userRepository.findByIdOrThrow(USER_ID)).thenReturn(user);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+
+        Mockito.when(accessChecker.hasAccessToCourse(USER_ID, COURSE_ID)).thenReturn(true);
+
+        Mockito.when(userCourseAccessRepository.findByUserIdAndCourseId(USER_ID, COURSE_ID))
+                .thenReturn(Optional.empty());
+
+        Assertions.assertThrows(EntityNotFoundException.class,
+                () -> accessService.deleteCourseAccessToUser(REQUEST_ID, requestCourseOnly));
+
+        Mockito.verify(userCourseAccessRepository, Mockito.never())
+                .deleteByUserIdAndCourseId(ArgumentMatchers.anyLong(), ArgumentMatchers.anyLong());
+        Mockito.verify(userModuleAccessRepository, Mockito.never())
+                .deleteAllByUserIdAndCourseId(ArgumentMatchers.anyLong(), ArgumentMatchers.anyLong());
+        Mockito.verifyNoInteractions(kafkaFacade);
+    }
+
+    @Test
+    void deleteModuleAccessToUser_accessExists_deletesAndSendsKafkaMessage() {
+        ModuleEntity module = TestEntityStubGenerator.constructModuleEntity();
+        module.setCourse(course);
+        Long moduleId = module.getId();
+        GetAccessRequest request = GetAccessRequest.builder()
+                .mentorId(MENTOR_ID)
+                .userId(USER_ID)
+                .courseId(COURSE_ID)
+                .moduleId(moduleId)
+                .build();
+
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(userRepository.findByIdOrThrow(USER_ID)).thenReturn(user);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+        Mockito.when(moduleRepository.findByIdOrThrow(moduleId)).thenReturn(module);
+
+        Mockito.when(accessChecker.hasAccessToCourse(USER_ID, COURSE_ID)).thenReturn(true);
+        Mockito.when(accessChecker.hasAccessToModule(USER_ID, moduleId)).thenReturn(true);
+
+        Mockito.when(userModuleAccessRepository.existsByUserIdAndModuleId(USER_ID, moduleId)).thenReturn(true);
+
+        accessService.deleteModuleAccessToUser(REQUEST_ID, request);
+
+        Mockito.verify(userModuleAccessRepository, Mockito.times(1))
+                .deleteByUserIdAndModuleId(USER_ID, moduleId);
+        Mockito.verify(kafkaFacade, Mockito.times(1))
+                .sendModuleAccessRevokedMessage(
+                        ArgumentMatchers.any(UserEntity.class),
+                        ArgumentMatchers.any(UserEntity.class),
+                        ArgumentMatchers.any(CourseEntity.class),
+                        ArgumentMatchers.any(ModuleEntity.class),
+                        ArgumentMatchers.any(LocalDateTime.class)
+                );
+    }
+
+    @Test
+    void deleteModuleAccessToUser_accessNotFound_throwsEntityNotFoundException() {
+        ModuleEntity module = TestEntityStubGenerator.constructModuleEntity();
+        module.setCourse(course);
+        Long moduleId = module.getId();
+        GetAccessRequest request = GetAccessRequest.builder()
+                .mentorId(MENTOR_ID)
+                .userId(USER_ID)
+                .courseId(COURSE_ID)
+                .moduleId(moduleId)
+                .build();
+
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(userRepository.findByIdOrThrow(USER_ID)).thenReturn(user);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+        Mockito.when(moduleRepository.findByIdOrThrow(moduleId)).thenReturn(module);
+
+        Mockito.when(accessChecker.hasAccessToCourse(USER_ID, COURSE_ID)).thenReturn(true);
+        Mockito.when(accessChecker.hasAccessToModule(USER_ID, moduleId)).thenReturn(true);
+
+        Mockito.when(userModuleAccessRepository.existsByUserIdAndModuleId(USER_ID, moduleId)).thenReturn(false);
+
+        Assertions.assertThrows(EntityNotFoundException.class,
+                () -> accessService.deleteModuleAccessToUser(REQUEST_ID, request));
+
+        Mockito.verify(userModuleAccessRepository, Mockito.never())
+                .deleteByUserIdAndModuleId(ArgumentMatchers.anyLong(), ArgumentMatchers.anyLong());
+        Mockito.verifyNoInteractions(kafkaFacade);
+    }
+
+    @Test
+    void getCourseAccessToUser_mentorNotAuthor_throwsCustomAccessDeniedException() {
+        UserEntity otherMentor = TestEntityStubGenerator.constructUserEntityWithRole(Role.MENTOR);
+        otherMentor.setId(99L);
+        CourseEntity courseWithOtherAuthor = TestEntityStubGenerator.constructCourseEntity();
+        courseWithOtherAuthor.setAuthor(otherMentor);
+        Long courseIdOther = courseWithOtherAuthor.getId();
+        GetAccessRequest request = GetAccessRequest.builder()
+                .mentorId(MENTOR_ID)
+                .userId(USER_ID)
+                .courseId(courseIdOther)
+                .build();
+
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(userRepository.findByIdOrThrow(USER_ID)).thenReturn(user);
+        Mockito.when(courseRepository.findByIdOrThrow(courseIdOther)).thenReturn(courseWithOtherAuthor);
+
+        Assertions.assertThrows(CustomAccessDeniedException.class,
+                () -> accessService.getCourseAccessToUser(REQUEST_ID, request));
+
+        Mockito.verify(userCourseAccessRepository, Mockito.never())
+                .save(ArgumentMatchers.any(UserCourseAccessEntity.class));
+        Mockito.verifyNoInteractions(kafkaFacade);
+    }
+
+    @Test
+    void getModuleAccessToUser_moduleNotInCourse_throwsEntityNotFoundException() {
+        CourseEntity otherCourse = TestEntityStubGenerator.constructCourseEntity();
+        otherCourse.setId(999L);
+        otherCourse.setAuthor(mentor);
+        ModuleEntity module = TestEntityStubGenerator.constructModuleEntity();
+        module.setCourse(otherCourse);
+        Long moduleId = module.getId();
+        GetAccessRequest request = GetAccessRequest.builder()
+                .mentorId(MENTOR_ID)
+                .userId(USER_ID)
+                .courseId(COURSE_ID)
+                .moduleId(moduleId)
+                .build();
+
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(userRepository.findByIdOrThrow(USER_ID)).thenReturn(user);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+        Mockito.when(moduleRepository.findByIdOrThrow(moduleId)).thenReturn(module);
+
+        Assertions.assertThrows(EntityNotFoundException.class,
+                () -> accessService.getModuleAccessToUser(REQUEST_ID, request));
+
+        Mockito.verify(userModuleAccessRepository, Mockito.never())
+                .save(ArgumentMatchers.any(UserModuleAccessEntity.class));
+        Mockito.verifyNoInteractions(kafkaFacade);
+    }
+}

--- a/mentor-service/src/test/java/ru/mentor/service/impl/ProgressServiceImplTest.java
+++ b/mentor-service/src/test/java/ru/mentor/service/impl/ProgressServiceImplTest.java
@@ -1,0 +1,279 @@
+package ru.mentor.service.impl;
+
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.mentor.constant.Role;
+import ru.mentor.dto.CourseProgressResponse;
+import ru.mentor.dto.MenteeProgressDto;
+import ru.mentor.entity.CourseEntity;
+import ru.mentor.entity.UserCourseAccessEntity;
+import ru.mentor.entity.UserEntity;
+import ru.mentor.exception.CustomAccessDeniedException;
+import ru.mentor.exception.EntityNotFoundException;
+import ru.mentor.repository.*;
+import ru.mentor.testUtil.TestEntityStubGenerator;
+
+import java.util.Collections;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+class ProgressServiceImplTest {
+
+    @Mock
+    private CourseRepository courseRepository;
+
+    @Mock
+    private ModuleRepository moduleRepository;
+
+    @Mock
+    private UserCourseAccessRepository userCourseAccessRepository;
+
+    @Mock
+    private UserModuleAccessRepository userModuleAccessRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ProgressServiceImpl progressService;
+
+    private static final Long MENTOR_ID = 1L;
+    private static final Long COURSE_ID = 1L;
+    private static final Long USER_ID = 2L;
+    private static final Long ADMIN_ID = 99L;
+    private static final Long OTHER_MENTOR_ID = 98L;
+
+    private UserEntity mentor;
+    private CourseEntity course;
+    private UserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        mentor = TestEntityStubGenerator.constructUserEntityWithRole(Role.MENTOR);
+        course = TestEntityStubGenerator.constructCourseEntity();
+        course.setAuthor(mentor);
+        user = UserEntity.builder()
+                .id(USER_ID)
+                .username("студент@test")
+                .firstName("Брэд")
+                .lastName("Пит")
+                .role(Role.USER)
+                .build();
+
+    }
+
+    @Test
+    void getCourseProgressByMentor_mentorIsAuthor_returnsResponseWithMenteesAndStatistic() {
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+
+        UserCourseAccessEntity access = UserCourseAccessEntity.builder()
+                .id(1L)
+                .user(user)
+                .course(course)
+                .accessGrantedBy(mentor)
+                .build();
+        Mockito.when(userCourseAccessRepository.findAllByCourseId(COURSE_ID))
+                .thenReturn(List.of(access));
+
+        Mockito.when(moduleRepository.findAllByCourseIdOrderByModuleOrderNumberAsc(COURSE_ID))
+                .thenReturn(Collections.emptyList());
+        Mockito.when(userModuleAccessRepository.findAllByUserIdAndCourseId(USER_ID, COURSE_ID))
+                .thenReturn(Collections.emptyList());
+
+        CourseProgressResponse response = progressService.getCourseProgressByMentor(MENTOR_ID, COURSE_ID);
+
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(COURSE_ID, response.getCourseId());
+        Assertions.assertNotNull(response.getMentee());
+        Assertions.assertEquals(1, response.getMentee().size());
+        Assertions.assertNotNull(response.getStatistic());
+        Assertions.assertEquals(1, response.getStatistic().getTotalMenteeCount());
+    }
+
+    @Test
+    void getCourseProgressByMentor_mentorIsAdmin_returnsResponse() {
+        UserEntity admin = UserEntity.builder()
+                .id(ADMIN_ID)
+                .username("admin@test")
+                .firstName("Админ")
+                .lastName("Административный")
+                .role(Role.ADMIN)
+                .build();
+        Mockito.when(userRepository.findByIdOrThrow(ADMIN_ID)).thenReturn(admin);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+        Mockito.when(userCourseAccessRepository.findAllByCourseId(COURSE_ID))
+                .thenReturn(Collections.emptyList());
+        Mockito.when(moduleRepository.findAllByCourseIdOrderByModuleOrderNumberAsc(COURSE_ID))
+                .thenReturn(Collections.emptyList());
+
+        CourseProgressResponse response = progressService.getCourseProgressByMentor(ADMIN_ID, COURSE_ID);
+
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(COURSE_ID, response.getCourseId());
+        Assertions.assertNotNull(response.getMentee());
+        Assertions.assertTrue(response.getMentee().isEmpty());
+        Assertions.assertNotNull(response.getStatistic());
+        Assertions.assertEquals(0, response.getStatistic().getTotalMenteeCount());
+    }
+
+    @Test
+    void getCourseProgressByMentor_mentorNotAuthor_throwsCustomAccessDeniedException() {
+        UserEntity otherMentor = TestEntityStubGenerator.constructUserEntityWithRole(Role.MENTOR);
+        otherMentor.setId(OTHER_MENTOR_ID);
+        CourseEntity courseOtherAuthor = TestEntityStubGenerator.constructCourseEntity();
+        courseOtherAuthor.setId(COURSE_ID);
+        courseOtherAuthor.setAuthor(otherMentor);
+
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(courseOtherAuthor);
+
+        Assertions.assertThrows(CustomAccessDeniedException.class,
+                () -> progressService.getCourseProgressByMentor(MENTOR_ID, COURSE_ID));
+    }
+
+    @Test
+    void getCourseProgressByMentor_courseNotFound_throwsEntityNotFoundException() {
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID))
+                .thenThrow(new EntityNotFoundException("Курс не найден"));
+
+        Assertions.assertThrows(EntityNotFoundException.class,
+                () -> progressService.getCourseProgressByMentor(MENTOR_ID, COURSE_ID));
+    }
+
+    @Test
+    void getCourseProgressByMentor_mentorNotFound_throwsEntityNotFoundException() {
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID))
+                .thenThrow(new EntityNotFoundException("Пользователь не найден"));
+
+        Assertions.assertThrows(EntityNotFoundException.class,
+                () -> progressService.getCourseProgressByMentor(MENTOR_ID, COURSE_ID));
+    }
+
+    @Test
+    void getCourseProgressByMentor_noMentees_returnsEmptyMenteeListAndZeroStatistic() {
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+        Mockito.when(userCourseAccessRepository.findAllByCourseId(COURSE_ID))
+                .thenReturn(Collections.emptyList());
+        Mockito.when(moduleRepository.findAllByCourseIdOrderByModuleOrderNumberAsc(COURSE_ID))
+                .thenReturn(Collections.emptyList());
+
+        CourseProgressResponse response = progressService.getCourseProgressByMentor(MENTOR_ID, COURSE_ID);
+
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(COURSE_ID, response.getCourseId());
+        Assertions.assertNotNull(response.getMentee());
+        Assertions.assertTrue(response.getMentee().isEmpty());
+        Assertions.assertNotNull(response.getStatistic());
+        Assertions.assertEquals(0, response.getStatistic().getTotalMenteeCount());
+    }
+
+    @Test
+    void getAllUsersAtCourse_mentorIsAuthor_returnsNonEmptyListOfMenteeProgressDto() {
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+
+        UserCourseAccessEntity access = UserCourseAccessEntity.builder()
+                .id(1L)
+                .user(user)
+                .course(course)
+                .accessGrantedBy(mentor)
+                .build();
+        Mockito.when(userCourseAccessRepository.findAllByCourseId(COURSE_ID))
+                .thenReturn(List.of(access));
+        Mockito.when(moduleRepository.findAllByCourseIdOrderByModuleOrderNumberAsc(COURSE_ID))
+                .thenReturn(Collections.emptyList());
+        Mockito.when(userModuleAccessRepository.findAllByUserIdAndCourseId(USER_ID, COURSE_ID))
+                .thenReturn(Collections.emptyList());
+
+        List<MenteeProgressDto> result = progressService.getAllUsersAtCourse(MENTOR_ID, COURSE_ID);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(USER_ID, result.getFirst().getUserId());
+        Assertions.assertEquals("Брэд", result.getFirst().getFirstName());
+        Assertions.assertEquals("Пит", result.getFirst().getLastName());
+    }
+
+    @Test
+    void getAllUsersAtCourse_mentorIsAdmin_returnsList() {
+        UserEntity admin = UserEntity.builder()
+                .id(ADMIN_ID)
+                .username("admin@test")
+                .firstName("Админ")
+                .lastName("Административный")
+                .role(Role.ADMIN)
+                .build();
+        Mockito.when(userRepository.findByIdOrThrow(ADMIN_ID)).thenReturn(admin);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+        Mockito.when(userCourseAccessRepository.findAllByCourseId(COURSE_ID))
+                .thenReturn(Collections.emptyList());
+        Mockito.when(moduleRepository.findAllByCourseIdOrderByModuleOrderNumberAsc(COURSE_ID))
+                .thenReturn(Collections.emptyList());
+
+        List<MenteeProgressDto> result = progressService.getAllUsersAtCourse(ADMIN_ID, COURSE_ID);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getAllUsersAtCourse_mentorNotAuthor_throwsCustomAccessDeniedException() {
+        UserEntity otherMentor = TestEntityStubGenerator.constructUserEntityWithRole(Role.MENTOR);
+        otherMentor.setId(OTHER_MENTOR_ID);
+        CourseEntity courseOtherAuthor = TestEntityStubGenerator.constructCourseEntity();
+        courseOtherAuthor.setId(COURSE_ID);
+        courseOtherAuthor.setAuthor(otherMentor);
+
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(courseOtherAuthor);
+
+        Assertions.assertThrows(CustomAccessDeniedException.class,
+                () -> progressService.getAllUsersAtCourse(MENTOR_ID, COURSE_ID));
+    }
+
+    @Test
+    void getAllUsersAtCourse_mentorNotFound_throwsEntityNotFoundException() {
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID))
+                .thenThrow(new EntityNotFoundException("Пользователь не найден"));
+
+        Assertions.assertThrows(EntityNotFoundException.class,
+                () -> progressService.getAllUsersAtCourse(MENTOR_ID, COURSE_ID));
+    }
+
+    @Test
+    void getAllUsersAtCourse_courseNotFound_throwsEntityNotFoundException() {
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID))
+                .thenThrow(new EntityNotFoundException("Курс не найден"));
+
+        Assertions.assertThrows(EntityNotFoundException.class,
+                () -> progressService.getAllUsersAtCourse(MENTOR_ID, COURSE_ID));
+    }
+
+    @Test
+    void getAllUsersAtCourse_noUsersAtCourse_returnsEmptyList() {
+        Mockito.when(userRepository.findByIdOrThrow(MENTOR_ID)).thenReturn(mentor);
+        Mockito.when(courseRepository.findByIdOrThrow(COURSE_ID)).thenReturn(course);
+        Mockito.when(userCourseAccessRepository.findAllByCourseId(COURSE_ID))
+                .thenReturn(Collections.emptyList());
+        Mockito.when(moduleRepository.findAllByCourseIdOrderByModuleOrderNumberAsc(COURSE_ID))
+                .thenReturn(Collections.emptyList());
+
+        List<MenteeProgressDto> result = progressService.getAllUsersAtCourse(MENTOR_ID, COURSE_ID);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isEmpty());
+    }
+}
+
+

--- a/notification-service/src/test/java/ru/mentor/service/impl/EmailSenderServiceImplTest.java
+++ b/notification-service/src/test/java/ru/mentor/service/impl/EmailSenderServiceImplTest.java
@@ -1,0 +1,41 @@
+package ru.mentor.service.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class EmailSenderServiceImplTest {
+
+    @Mock
+    private JavaMailSender emailSender;
+
+    @InjectMocks
+    private EmailSenderServiceImpl emailSenderService;
+
+    private static final String TO_ADDRESS = "пользователь@example.com";
+    private static final String SUBJECT = "Тестовая тема";
+    private static final String MESSAGE = "Сообщение";
+
+    @Test
+    void sendEmail_sendsCorrectMessage(){
+        emailSenderService.sendEmail(TO_ADDRESS, SUBJECT, MESSAGE);
+
+        ArgumentCaptor<SimpleMailMessage> captor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+        verify(emailSender).send(captor.capture());
+
+        SimpleMailMessage sent = captor.getValue();
+        assertNotNull(sent);
+        assertArrayEquals(new String[]{TO_ADDRESS}, sent.getTo());
+        assertEquals(SUBJECT, sent.getSubject());
+        assertEquals(MESSAGE, sent.getText());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,9 @@
 
     <docker.tag>local</docker.tag>
     <docker.java-image>openjdk:21</docker.java-image>
+
+    <!-- Задаётся jacoco-maven-plugin (prepare-agent); здесь — чтобы IDE не ругалась на @{argLine} -->
+    <argLine></argLine>
   </properties>
 
   <profiles>
@@ -199,8 +202,33 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
-            <argLine>--add-opens java.base/java.nio=ALL-UNNAMED</argLine>
+            <argLine>@{argLine} --add-opens java.base/java.nio=ALL-UNNAMED</argLine>
           </configuration>
+        </plugin>
+
+        <!-- JaCoCo: замер покрытия тестами (отчёт в target/site/jacoco после mvn test) -->
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.11</version>
+          <executions>
+            <execution>
+              <id>prepare-agent</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+              <configuration>
+                <propertyName>argLine</propertyName>
+              </configuration>
+            </execution>
+            <execution>
+              <id>report</id>
+              <phase>test</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
 
         <!-- Checkstyle -->
@@ -267,6 +295,11 @@
     </pluginManagement>
 
     <plugins>
+      <!-- Конфигурация executions наследуется из pluginManagement выше — без дублирования -->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>

--- a/reactive-common-lib/src/test/java/ru/mentor/mapper/AdminModuleMapperTest.java
+++ b/reactive-common-lib/src/test/java/ru/mentor/mapper/AdminModuleMapperTest.java
@@ -1,9 +1,11 @@
 package ru.mentor.mapper;
 
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import ru.mentor.common.AllModulesResponse;
+import ru.mentor.common.CreateModuleGrpcRequest;
 import ru.mentor.common.ModuleResponse;
 import ru.mentor.entity.CourseEntity;
 import ru.mentor.entity.ModuleEntity;
@@ -77,6 +79,39 @@ class AdminModuleMapperTest {
                 TestConstantHolder.MODULE_CREATED_AT_EPOCH_SECONDS,
                 response.getCreatedAt().getSeconds()
         );
+    }
+
+    @Test
+    void mapModuleEntityListToModuleResponseList_mapsEachElement() {
+        ModuleEntity m1 = TestEntityStubGenerator.constructModuleEntity();
+        m1.setId(101L);
+        ModuleEntity m2 = TestEntityStubGenerator.constructModuleEntity();
+        m2.setId(102L);
+
+        List<ModuleResponse> list = mapper.mapModuleEntityListToModuleResponseList(List.of(m1, m2));
+
+        Assertions.assertEquals(2, list.size());
+        Assertions.assertEquals(101L, list.get(0).getModuleId());
+        Assertions.assertEquals(102L, list.get(1).getModuleId());
+    }
+
+    @Test
+    void mapCreateModuleGrpcRequestToModuleEntity_setsFieldsFromRequest() {
+        CreateModuleGrpcRequest grpc = CreateModuleGrpcRequest.newBuilder()
+                .setTitle("T")
+                .setContent("content")
+                .setOrderNumber(3)
+                .setCourseId(9L)
+                .build();
+
+        ModuleEntity entity = mapper.mapCreateModuleGrpcRequestToModuleEntity(grpc);
+
+        Assertions.assertEquals("T", entity.getModuleTitle());
+        Assertions.assertEquals("content", entity.getModuleContent());
+        Assertions.assertEquals(3, entity.getModuleOrderNumber());
+        Assertions.assertEquals(9L, entity.getCourseId());
+        Assertions.assertTrue(entity.getIsActive());
+        Assertions.assertNotNull(entity.getCreatedAt());
     }
 
 }

--- a/reactive-common-lib/src/test/java/ru/mentor/mapper/TagMapperTest.java
+++ b/reactive-common-lib/src/test/java/ru/mentor/mapper/TagMapperTest.java
@@ -1,0 +1,56 @@
+package ru.mentor.mapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import ru.mentor.common.CourseTagResponse;
+import ru.mentor.common.ListCourseTagsResponse;
+import ru.mentor.entity.CourseTagEntity;
+
+class TagMapperTest {
+
+    private final TagMapper mapper = new TagMapper();
+
+    @Test
+    void toGrpcTagResponse_mapsFields() {
+        LocalDateTime created = LocalDateTime.of(2026, 4, 2, 10, 0);
+        CourseTagEntity entity = CourseTagEntity.builder()
+                .id(5L)
+                .tagName("spring")
+                .isActive(true)
+                .createdAt(created)
+                .build();
+
+        CourseTagResponse grpc = mapper.toGrpcTagResponse(entity);
+
+        Assertions.assertEquals(5L, grpc.getId());
+        Assertions.assertEquals("spring", grpc.getName());
+        Assertions.assertTrue(grpc.getIsActive());
+        Assertions.assertEquals(
+                created.toEpochSecond(java.time.ZoneOffset.UTC),
+                grpc.getCreatedAt().getSeconds());
+    }
+
+    @Test
+    void toGrpcTagsListResponse_mapsEachTag() {
+        CourseTagEntity t1 = CourseTagEntity.builder()
+                .id(1L)
+                .tagName("a")
+                .isActive(true)
+                .createdAt(LocalDateTime.of(2026, 1, 1, 0, 0))
+                .build();
+        CourseTagEntity t2 = CourseTagEntity.builder()
+                .id(2L)
+                .tagName("b")
+                .isActive(false)
+                .createdAt(LocalDateTime.of(2026, 1, 2, 0, 0))
+                .build();
+
+        ListCourseTagsResponse list = mapper.toGrpcTagsListResponse(List.of(t1, t2));
+
+        Assertions.assertEquals(2, list.getTagsCount());
+        Assertions.assertEquals("a", list.getTags(0).getName());
+        Assertions.assertEquals("b", list.getTags(1).getName());
+    }
+}


### PR DESCRIPTION
## LEPL-12

Добавлены и расширены unit-тесты: **api-gateway** — контроллеры (Access, Progress, Module, CourseTag), актуализация **ModuleMapperTest** и **GrpcExceptionMapperTest** под текущий API после слияния с **develop**; **common-lib** — **ProtoTimeMapper**, **UserMapper**, **BaseMapper**, расширены **KafkaMapperTest**, **UtilMapperTest**, **MarkdownFileValidatorTest**; **reactive-common-lib** — **TagMapperTest**, дополнения в **AdminModuleMapperTest**.

Ветка включала merge с `origin/develop` и подтягивание с форка (в истории есть тесты коллеги по **mentor-service**). **PR в `develop`.**

Полный прогон: `mvn clean test -T 1` из корня проходит успешно.

Made with [Cursor](https://cursor.com)